### PR TITLE
Support Metro as included build

### DIFF
--- a/.github/actions/setup-action/action.yml
+++ b/.github/actions/setup-action/action.yml
@@ -5,6 +5,9 @@ inputs:
   gradle-encryption-key:
     description: "The key used to encrypt the Gradle cache"
     required: true
+  java-version:
+    description: "The Java version to install"
+    default: '21'
 
 runs:
   using: "composite"
@@ -12,7 +15,7 @@ runs:
     - uses: actions/setup-java@v4
       with:
         distribution: 'zulu'
-        java-version: 21
+        java-version: ${{ inputs.java-version }}
 
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v4

--- a/.github/workflows/metro-compatibility.yml
+++ b/.github/workflows/metro-compatibility.yml
@@ -1,0 +1,48 @@
+name: Metro Compatibility
+
+on:
+  # Daily at 8:00 UTC. Needed because there's no trigger when the main branch in Metro changes.
+  schedule:
+    - cron: '0 8 * * *'
+
+  # Allow manual trigger.
+  workflow_dispatch:
+
+  # Verify for PRs as well.
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  metro-compatibility:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Checkout Metro
+        uses: actions/checkout@v4
+        with:
+          repository: ZacSweers/metro
+          path: metro
+
+      - name: Setup
+        uses: ./.github/actions/setup-action
+        with:
+          gradle-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          java-version: '24'
+
+      - name: Compiler tests
+        run: ./gradlew :compiler:test -PuseLocalMetro -PlocalMetroPath=metro --stacktrace --show-version
+
+      - name: Integration tests
+        run: ./gradlew -p integration-tests test -PuseLocalMetro -PlocalMetroPath=metro --stacktrace --show-version
+
+      - name: Upload Test Results
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: metro-compat-test-results
+          path: ./**/build/reports/

--- a/README.md
+++ b/README.md
@@ -40,6 +40,25 @@ plugins {
 }
 ```
 
+## Development
+
+To build and test against a local checkout of Metro (expected at `../metro`), pass the
+`-PuseLocalMetro` flag:
+
+```bash
+./gradlew :compiler:test -PuseLocalMetro
+```
+
+This includes the Metro project as a Gradle included build and substitutes the
+`dev.zacsweers.metro:compiler`, `dev.zacsweers.metro:runtime`, and `dev.zacsweers.metro` plugin
+dependencies with the local source. Without the flag, published Maven artifacts are used.
+
+To use a different path for the Metro checkout, pass `-PlocalMetroPath=<path>`:
+
+```bash
+./gradlew :compiler:test -PuseLocalMetro -PlocalMetroPath=/path/to/metro
+```
+
 ## License
 
 ```

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,9 @@
 pluginManagement {
   includeBuild('build-logic')
   includeBuild('gradle-plugin')
+  if (settings.hasProperty('useLocalMetro')) {
+    includeBuild(settings.hasProperty('localMetroPath') ? localMetroPath : '../metro')
+  }
 
   repositories {
     mavenCentral()
@@ -11,6 +14,16 @@ pluginManagement {
 includeBuild('gradle-plugin') {
   dependencySubstitution {
     substitute module("$GROUP:gradle-plugin") using project(':')
+  }
+}
+
+if (settings.hasProperty('useLocalMetro')) {
+  def metroPath = settings.hasProperty('localMetroPath') ? localMetroPath : '../metro'
+  includeBuild(metroPath) {
+    dependencySubstitution {
+      substitute module('dev.zacsweers.metro:compiler') using project(':compiler')
+      substitute module('dev.zacsweers.metro:runtime') using project(':runtime')
+    }
   }
 }
 


### PR DESCRIPTION
Through a Gradle property Metro can be included from source.

Setup a daily cron job that builds this with Metro from source and runs the tests. This will help to detect regressions in Metro that break our extensions.