### PR TITLE
Add self-hosted Renovate GitHub Action workflow

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,23 @@
+name: Renovate
+
+on:
+  schedule:
+    # Run every hour
+    - cron: '0 6,18 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: renovatebot/github-action@v46.1.1
+        with:
+          token: ${{ secrets.RENOVATE_TOKEN }}
+        env:
+          LOG_LEVEL: info


### PR DESCRIPTION
The Mend.io hosted Renovate app wasn't detecting dependencies. Switch to the self-hosted GitHub Action running twice daily instead.