### PR TITLE
Use Metro scope annotations

### DIFF
--- a/compiler/src/main/kotlin/com/squareup/metro/extensions/ClassIds.kt
+++ b/compiler/src/main/kotlin/com/squareup/metro/extensions/ClassIds.kt
@@ -24,10 +24,7 @@ internal object ClassIds {
 
   val INTO_SET = ClassId(FqName("dev.zacsweers.metro"), Name.identifier("IntoSet"))
 
-  // Use com.squareup.dagger.ForScope (the project's custom qualifier), NOT
-  // dev.zacsweers.metro.ForScope. The graph accessor methods use @com.squareup.dagger.ForScope
-  // to qualify Set<Scoped> multibindings, so the @Binds function must use the same annotation.
-  val FOR_SCOPE = ClassId(FqName("com.squareup.dagger"), Name.identifier("ForScope"))
+  val FOR_SCOPE = ClassId(FqName("dev.zacsweers.metro"), Name.identifier("ForScope"))
 
   val SCREEN_ROBOT =
     ClassId(FqName("com.squareup.instrumentation.robots"), Name.identifier("ScreenRobot"))
@@ -42,7 +39,7 @@ internal object ClassIds {
 
   val PROVIDES = ClassId(FqName("dev.zacsweers.metro"), Name.identifier("Provides"))
 
-  val SINGLE_IN = ClassId(FqName("com.squareup.dagger"), Name.identifier("SingleIn"))
+  val SINGLE_IN = ClassId(FqName("dev.zacsweers.metro"), Name.identifier("SingleIn"))
 
   val PROVIDER = ClassId(FqName("dev.zacsweers.metro"), Name.identifier("Provider"))
 
@@ -54,7 +51,7 @@ internal object ClassIds {
 
   val FEATURE_FLAG = ClassId(FqName("com.squareup.featureflags"), Name.identifier("FeatureFlag"))
 
-  val APP_SCOPE = ClassId(FqName("com.squareup.dagger"), Name.identifier("AppScope"))
+  val APP_SCOPE = ClassId(FqName("dev.zacsweers.metro"), Name.identifier("AppScope"))
 
   val DEVELOPMENT_APP_COMPONENT =
     ClassId(FqName("com.squareup.development.shell"), Name.identifier("DevelopmentAppComponent"))

--- a/compiler/src/main/kotlin/com/squareup/metro/extensions/developmentapp/DevelopmentAppComponentFir.kt
+++ b/compiler/src/main/kotlin/com/squareup/metro/extensions/developmentapp/DevelopmentAppComponentFir.kt
@@ -205,7 +205,7 @@ public class DevelopmentAppComponentFir(session: FirSession) :
       annotations +=
         buildAnnotationCallWithScope(
           ClassIds.SINGLE_IN,
-          ArgNames.VALUE,
+          ArgNames.SCOPE,
           buildAppScopeClassExpression()!!,
           classSymbol,
           session,

--- a/compiler/src/main/kotlin/com/squareup/metro/extensions/scoped/ContributesMultibindingScopedFir.kt
+++ b/compiler/src/main/kotlin/com/squareup/metro/extensions/scoped/ContributesMultibindingScopedFir.kt
@@ -256,7 +256,7 @@ public class ContributesMultibindingScopedFir(session: FirSession) :
       annotations +=
         buildAnnotationCallWithScope(
           ClassIds.FOR_SCOPE,
-          ArgNames.VALUE,
+          ArgNames.SCOPE,
           scopeArg,
           functionSymbol,
           session,

--- a/compiler/src/main/kotlin/com/squareup/metro/extensions/service/ContributesServiceFir.kt
+++ b/compiler/src/main/kotlin/com/squareup/metro/extensions/service/ContributesServiceFir.kt
@@ -340,7 +340,7 @@ public class ContributesServiceFir(session: FirSession) :
       annotations +=
         buildAnnotationCallWithScope(
           ClassIds.SINGLE_IN,
-          ArgNames.VALUE,
+          ArgNames.SCOPE,
           scopeArg,
           functionSymbol,
           session,
@@ -428,7 +428,7 @@ public class ContributesServiceFir(session: FirSession) :
       annotations +=
         buildAnnotationCallWithScope(
           ClassIds.SINGLE_IN,
-          ArgNames.VALUE,
+          ArgNames.SCOPE,
           scopeArg,
           realFnSymbol,
           session,

--- a/compiler/src/test/resources/box/contributesfeatureflag/dynamicConfigurationFlag.kt
+++ b/compiler/src/test/resources/box/contributesfeatureflag/dynamicConfigurationFlag.kt
@@ -1,6 +1,6 @@
 package com.test
 
-import com.squareup.dagger.AppScope
+import dev.zacsweers.metro.AppScope
 import com.squareup.featureflags.BooleanFeatureFlag
 import com.squareup.featureflags.FeatureFlag
 import com.squareup.featureflags.anvil.ContributesDynamicConfigurationFlag

--- a/compiler/src/test/resources/box/contributesfeatureflag/multiCompilation.kt
+++ b/compiler/src/test/resources/box/contributesfeatureflag/multiCompilation.kt
@@ -10,7 +10,7 @@ import com.squareup.featureflags.anvil.Month.April
 object LibFeatureFlag : BooleanFeatureFlag("lib-flag-key")
 
 // MODULE: main(lib)
-import com.squareup.dagger.AppScope
+import dev.zacsweers.metro.AppScope
 import com.squareup.featureflags.FeatureFlag
 
 @DependencyGraph(AppScope::class)

--- a/compiler/src/test/resources/box/contributesfeatureflag/multipleFlags.kt
+++ b/compiler/src/test/resources/box/contributesfeatureflag/multipleFlags.kt
@@ -1,6 +1,6 @@
 package com.test
 
-import com.squareup.dagger.AppScope
+import dev.zacsweers.metro.AppScope
 import com.squareup.featureflags.BooleanFeatureFlag
 import com.squareup.featureflags.FeatureFlag
 import com.squareup.featureflags.StringFeatureFlag

--- a/compiler/src/test/resources/box/contributesfeatureflag/singleCompilation.kt
+++ b/compiler/src/test/resources/box/contributesfeatureflag/singleCompilation.kt
@@ -1,6 +1,6 @@
 package com.test
 
-import com.squareup.dagger.AppScope
+import dev.zacsweers.metro.AppScope
 import com.squareup.featureflags.BooleanFeatureFlag
 import com.squareup.featureflags.FeatureFlag
 import com.squareup.featureflags.anvil.ContributesFeatureFlag

--- a/compiler/src/test/resources/box/contributesmultibindingscoped/excludedScopedBinding.kt
+++ b/compiler/src/test/resources/box/contributesmultibindingscoped/excludedScopedBinding.kt
@@ -1,7 +1,7 @@
 package com.test
 
 import com.squareup.dagger.ContributesMultibindingScoped
-import com.squareup.dagger.ForScope
+import dev.zacsweers.metro.ForScope
 import mortar.Scoped
 
 @Inject

--- a/compiler/src/test/resources/box/contributesmultibindingscoped/multiCompilation.kt
+++ b/compiler/src/test/resources/box/contributesmultibindingscoped/multiCompilation.kt
@@ -10,7 +10,7 @@ class MyTestClass : Scoped
 
 // MODULE: main(lib)
 import mortar.Scoped
-import com.squareup.dagger.ForScope
+import dev.zacsweers.metro.ForScope
 
 @DependencyGraph(Unit::class)
 interface MyGraph {

--- a/compiler/src/test/resources/box/contributesmultibindingscoped/replacedScopedBinding.kt
+++ b/compiler/src/test/resources/box/contributesmultibindingscoped/replacedScopedBinding.kt
@@ -1,7 +1,7 @@
 package com.test
 
 import com.squareup.dagger.ContributesMultibindingScoped
-import com.squareup.dagger.ForScope
+import dev.zacsweers.metro.ForScope
 import mortar.Scoped
 
 interface MyService

--- a/compiler/src/test/resources/box/contributesmultibindingscoped/replacedScopedBindingMultiCompilation.kt
+++ b/compiler/src/test/resources/box/contributesmultibindingscoped/replacedScopedBindingMultiCompilation.kt
@@ -22,7 +22,7 @@ class Service1 : Scoped, MyService
 class Service3 : Scoped
 
 // MODULE: main(lib)
-import com.squareup.dagger.ForScope
+import dev.zacsweers.metro.ForScope
 import com.test.MyService
 import com.test.Service1
 import com.test.Service3

--- a/compiler/src/test/resources/box/contributesmultibindingscoped/replacedScopedBindingMultiCompilationWithExtension.kt
+++ b/compiler/src/test/resources/box/contributesmultibindingscoped/replacedScopedBindingMultiCompilationWithExtension.kt
@@ -8,7 +8,7 @@
 package com.test
 
 import com.squareup.dagger.ContributesMultibindingScoped
-import com.squareup.dagger.ForScope
+import dev.zacsweers.metro.ForScope
 import mortar.Scoped
 
 @GraphExtension(String::class)
@@ -37,7 +37,7 @@ class Service1 : Scoped, MyService
 class Service3 : Scoped
 
 // MODULE: main(lib)
-import com.squareup.dagger.ForScope
+import dev.zacsweers.metro.ForScope
 import com.test.ExtendedGraph
 import com.test.MyService
 import com.test.Service1

--- a/compiler/src/test/resources/box/contributesmultibindingscoped/scopedInSuperTypes.kt
+++ b/compiler/src/test/resources/box/contributesmultibindingscoped/scopedInSuperTypes.kt
@@ -1,7 +1,7 @@
 package com.test
 
 import com.squareup.dagger.ContributesMultibindingScoped
-import com.squareup.dagger.ForScope
+import dev.zacsweers.metro.ForScope
 import mortar.Scoped
 
 interface BaseInterface : Scoped

--- a/compiler/src/test/resources/box/contributesmultibindingscoped/singleCompilation.kt
+++ b/compiler/src/test/resources/box/contributesmultibindingscoped/singleCompilation.kt
@@ -1,7 +1,7 @@
 package com.test
 
 import com.squareup.dagger.ContributesMultibindingScoped
-import com.squareup.dagger.ForScope
+import dev.zacsweers.metro.ForScope
 import mortar.Scoped
 
 @Inject

--- a/compiler/src/test/resources/box/contributesservice/multiCompilation.kt
+++ b/compiler/src/test/resources/box/contributesservice/multiCompilation.kt
@@ -13,7 +13,7 @@ package com.test
 
 import com.squareup.api.RetrofitAuthenticated
 import com.squareup.api.ServiceCreator
-import com.squareup.dagger.SingleIn
+import dev.zacsweers.metro.SingleIn
 import com.squareup.development.FakeMode
 
 @DependencyGraph(Unit::class)

--- a/compiler/src/test/resources/box/contributesservice/replacedMultipleServices.kt
+++ b/compiler/src/test/resources/box/contributesservice/replacedMultipleServices.kt
@@ -3,7 +3,7 @@ package com.test
 import com.squareup.api.RealService
 import com.squareup.api.RetrofitAuthenticated
 import com.squareup.api.ServiceCreator
-import com.squareup.dagger.SingleIn
+import dev.zacsweers.metro.SingleIn
 import com.squareup.development.FakeMode
 import com.squareup.services.anvil.ContributesService
 

--- a/compiler/src/test/resources/box/contributesservice/replacedServiceDoesNotInstantiateFakeInRealMode.kt
+++ b/compiler/src/test/resources/box/contributesservice/replacedServiceDoesNotInstantiateFakeInRealMode.kt
@@ -2,7 +2,7 @@ package com.test
 
 import com.squareup.api.RetrofitAuthenticated
 import com.squareup.api.ServiceCreator
-import com.squareup.dagger.SingleIn
+import dev.zacsweers.metro.SingleIn
 import com.squareup.development.FakeMode
 import com.squareup.services.anvil.ContributesService
 

--- a/compiler/src/test/resources/box/contributesservice/replacedServiceOneCompilation.kt
+++ b/compiler/src/test/resources/box/contributesservice/replacedServiceOneCompilation.kt
@@ -3,7 +3,7 @@ package com.test
 import com.squareup.api.RealService
 import com.squareup.api.RetrofitAuthenticated
 import com.squareup.api.ServiceCreator
-import com.squareup.dagger.SingleIn
+import dev.zacsweers.metro.SingleIn
 import com.squareup.development.FakeMode
 import com.squareup.services.anvil.ContributesService
 

--- a/compiler/src/test/resources/box/contributesservice/replacedServiceSameLibSeparateGraph.kt
+++ b/compiler/src/test/resources/box/contributesservice/replacedServiceSameLibSeparateGraph.kt
@@ -23,7 +23,7 @@ package com.test
 import com.squareup.api.RealService
 import com.squareup.api.RetrofitAuthenticated
 import com.squareup.api.ServiceCreator
-import com.squareup.dagger.SingleIn
+import dev.zacsweers.metro.SingleIn
 import com.squareup.development.FakeMode
 
 @DependencyGraph(Unit::class)

--- a/compiler/src/test/resources/box/contributesservice/replacedServiceThreeCompilations.kt
+++ b/compiler/src/test/resources/box/contributesservice/replacedServiceThreeCompilations.kt
@@ -23,7 +23,7 @@ package com.test
 import com.squareup.api.RealService
 import com.squareup.api.RetrofitAuthenticated
 import com.squareup.api.ServiceCreator
-import com.squareup.dagger.SingleIn
+import dev.zacsweers.metro.SingleIn
 import com.squareup.development.FakeMode
 
 @DependencyGraph(Unit::class)

--- a/compiler/src/test/resources/box/contributesservice/replacedServiceTwoCompilations.kt
+++ b/compiler/src/test/resources/box/contributesservice/replacedServiceTwoCompilations.kt
@@ -14,7 +14,7 @@ package com.test
 import com.squareup.api.RealService
 import com.squareup.api.RetrofitAuthenticated
 import com.squareup.api.ServiceCreator
-import com.squareup.dagger.SingleIn
+import dev.zacsweers.metro.SingleIn
 import com.squareup.development.FakeMode
 import com.squareup.services.anvil.ContributesService
 

--- a/compiler/src/test/resources/box/contributesservice/singleCompilation.kt
+++ b/compiler/src/test/resources/box/contributesservice/singleCompilation.kt
@@ -2,7 +2,7 @@ package com.test
 
 import com.squareup.api.RetrofitAuthenticated
 import com.squareup.api.ServiceCreator
-import com.squareup.dagger.SingleIn
+import dev.zacsweers.metro.SingleIn
 import com.squareup.development.FakeMode
 import com.squareup.services.anvil.ContributesService
 

--- a/compiler/src/test/resources/box/developmentappcomponent/excludeLoggedInComponent.kt
+++ b/compiler/src/test/resources/box/developmentappcomponent/excludeLoggedInComponent.kt
@@ -10,7 +10,7 @@
 // MODULE: deps
 package com.squareup.development.shell.login.screen
 
-import com.squareup.dagger.AppScope
+import dev.zacsweers.metro.AppScope
 
 @ContributesTo(AppScope::class)
 interface LoginScreenModule {
@@ -26,7 +26,7 @@ class DevelopmentLoggedInComponent
 package com.test
 
 import android.app.Application
-import com.squareup.dagger.AppScope
+import dev.zacsweers.metro.AppScope
 import com.squareup.development.shell.DevelopmentAppComponent
 import com.squareup.development.shell.DevelopmentApplication
 

--- a/compiler/src/test/resources/box/developmentappcomponent/featureScopeComponent.kt
+++ b/compiler/src/test/resources/box/developmentappcomponent/featureScopeComponent.kt
@@ -48,7 +48,7 @@ annotation class DevelopmentFeatureScopeComponent
 package com.test
 
 import android.app.Application
-import com.squareup.dagger.AppScope
+import dev.zacsweers.metro.AppScope
 import com.squareup.development.shell.DevelopmentAppComponent
 import com.squareup.development.shell.DevelopmentApplication
 import com.squareup.development.shell.login.screen.FeatureProvider

--- a/compiler/src/test/resources/dump/contributesfeatureflag/contributesFeatureFlag.fir.kt.txt
+++ b/compiler/src/test/resources/dump/contributesfeatureflag/contributesFeatureFlag.fir.kt.txt
@@ -15,7 +15,7 @@ object MyFeatureFlag : BooleanFeatureFlag {
   interface FeatureFlagContribution {
     @Deprecated(message = "This synthesized declaration should not be used directly", level = DeprecationLevel.HIDDEN)
     @MetroContribution(scope = AppScope::class)
-    interface MetroContributionToComsquareupdaggerappScopegan-ZFI : FeatureFlagContribution {
+    interface MetroContributionToDevzacsweersmetroappScopeoxd1AHI : FeatureFlagContribution {
     }
 
     @Deprecated(message = "This synthesized declaration should not be used directly", level = DeprecationLevel.HIDDEN)

--- a/compiler/src/test/resources/dump/contributesfeatureflag/contributesFeatureFlag.fir.txt
+++ b/compiler/src/test/resources/dump/contributesfeatureflag/contributesFeatureFlag.fir.txt
@@ -6,10 +6,10 @@ FILE: contributesFeatureFlag.kt
             super<R|com/squareup/featureflags/BooleanFeatureFlag|>(String(my-flag-key))
         }
 
-        @R|dev/zacsweers/metro/ContributesTo|(scope = <getClass>(Q|com/squareup/dagger/AppScope|)) @R|dev/zacsweers/metro/Origin|(value = <getClass>(Q|com/test/MyFeatureFlag|)) public abstract interface FeatureFlagContribution : R|kotlin/Any| {
+        @R|dev/zacsweers/metro/ContributesTo|(scope = <getClass>(Q|dev/zacsweers/metro/AppScope|)) @R|dev/zacsweers/metro/Origin|(value = <getClass>(Q|com/test/MyFeatureFlag|)) public abstract interface FeatureFlagContribution : R|kotlin/Any| {
             @R|dev/zacsweers/metro/Provides|() @R|dev/zacsweers/metro/IntoSet|() public open fun providesMyFeatureFlag(): R|com/squareup/featureflags/FeatureFlag|
 
-            @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) @R|dev/zacsweers/metro/internal/MetroContribution|(scope = <getClass>(Q|com/squareup/dagger/AppScope|)) public abstract interface MetroContributionToComsquareupdaggerappScopegan-ZFI : R|com/test/MyFeatureFlag.FeatureFlagContribution| {
+            @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) @R|dev/zacsweers/metro/internal/MetroContribution|(scope = <getClass>(Q|dev/zacsweers/metro/AppScope|)) public abstract interface MetroContributionToDevzacsweersmetroappScopeoxd1AHI : R|com/test/MyFeatureFlag.FeatureFlagContribution| {
             }
 
             @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) @R|dev/zacsweers/metro/internal/CallableMetadata|(callableName = String(providesMyFeatureFlag), propertyName = String(), startOffset = Int(-1), endOffset = Int(-1), newInstanceName = String(providesMyFeatureFlag)) public final class ProvidesMyFeatureFlagMetroFactory : R|kotlin/Any| {

--- a/compiler/src/test/resources/dump/contributesmultibindingscoped/contributesMultibindingScoped.fir.txt
+++ b/compiler/src/test/resources/dump/contributesmultibindingscoped/contributesMultibindingScoped.fir.txt
@@ -7,7 +7,7 @@ FILE: contributesMultibindingScoped.kt
         }
 
         @R|dev/zacsweers/metro/ContributesTo|(scope = <getClass>(Q|kotlin/Unit|)) @R|dev/zacsweers/metro/Origin|(value = <getClass>(Q|com/test/MyTestClass|)) public abstract interface MultibindingScopedContribution : R|kotlin/Any| {
-            @R|dev/zacsweers/metro/Binds|() @R|dev/zacsweers/metro/IntoSet|() @R|com/squareup/dagger/ForScope|(value = <getClass>(Q|kotlin/Unit|)) public abstract fun bindsMyTestClass(myTestClass: R|com/test/MyTestClass|): R|mortar/Scoped|
+            @R|dev/zacsweers/metro/Binds|() @R|dev/zacsweers/metro/IntoSet|() @R|dev/zacsweers/metro/ForScope|(scope = <getClass>(Q|kotlin/Unit|)) public abstract fun bindsMyTestClass(myTestClass: R|com/test/MyTestClass|): R|mortar/Scoped|
 
             @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) @R|dev/zacsweers/metro/internal/MetroContribution|(scope = <getClass>(Q|kotlin/Unit|)) public abstract interface MetroContributionToKotlinunitdHiVAhs : R|com/test/MyTestClass.MultibindingScopedContribution| {
             }

--- a/compiler/src/test/resources/dump/contributesmultibindingscoped/scopedInSuperTypes.fir.txt
+++ b/compiler/src/test/resources/dump/contributesmultibindingscoped/scopedInSuperTypes.fir.txt
@@ -9,7 +9,7 @@ FILE: scopedInSuperTypes.kt
         }
 
         @R|dev/zacsweers/metro/ContributesTo|(scope = <getClass>(Q|kotlin/Unit|)) @R|dev/zacsweers/metro/Origin|(value = <getClass>(Q|com/test/Service|)) public abstract interface MultibindingScopedContribution : R|kotlin/Any| {
-            @R|dev/zacsweers/metro/Binds|() @R|dev/zacsweers/metro/IntoSet|() @R|com/squareup/dagger/ForScope|(value = <getClass>(Q|kotlin/Unit|)) public abstract fun bindsService(service: R|com/test/Service|): R|mortar/Scoped|
+            @R|dev/zacsweers/metro/Binds|() @R|dev/zacsweers/metro/IntoSet|() @R|dev/zacsweers/metro/ForScope|(scope = <getClass>(Q|kotlin/Unit|)) public abstract fun bindsService(service: R|com/test/Service|): R|mortar/Scoped|
 
             @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) @R|dev/zacsweers/metro/internal/MetroContribution|(scope = <getClass>(Q|kotlin/Unit|)) public abstract interface MetroContributionToKotlinunitdHiVAhs : R|com/test/Service.MultibindingScopedContribution| {
             }

--- a/compiler/src/test/resources/dump/contributesservice/contributesService.fir.kt.txt
+++ b/compiler/src/test/resources/dump/contributesservice/contributesService.fir.kt.txt
@@ -60,7 +60,7 @@ interface MyService {
         return Companion.provideMyService(instance = <this>.#instance, serviceCreator = <this>.#serviceCreator.invoke(), isFakeMode = <this>.#isFakeMode.invoke())
       }
 
-      @SingleIn(value = Unit::class)
+      @SingleIn(scope = Unit::class)
       @HiddenFromObjC
       fun mirrorFunction(@RetrofitAuthenticated serviceCreator: ServiceCreator, @FakeMode isFakeMode: Boolean): MyService {
         return error(message = "Never called")
@@ -69,7 +69,7 @@ interface MyService {
     }
 
     @Provides
-    @SingleIn(value = Unit::class)
+    @SingleIn(scope = Unit::class)
     fun provideMyService(@RetrofitAuthenticated serviceCreator: ServiceCreator, @FakeMode isFakeMode: Boolean): MyService {
       when {
         isFakeMode -> error(message = "No fake service provided for MyService.")

--- a/compiler/src/test/resources/dump/contributesservice/contributesService.fir.txt
+++ b/compiler/src/test/resources/dump/contributesservice/contributesService.fir.txt
@@ -3,7 +3,7 @@ FILE: contributesService.kt
 
     @R|com/squareup/services/anvil/ContributesService|(scope = <getClass>(Q|kotlin/Unit|)) @R|com/squareup/api/RetrofitAuthenticated|() public abstract interface MyService : R|kotlin/Any| {
         @R|dev/zacsweers/metro/ContributesTo|(scope = <getClass>(Q|kotlin/Unit|)) @R|dev/zacsweers/metro/Origin|(value = <getClass>(Q|com/test/MyService|)) public abstract interface ServiceContribution : R|kotlin/Any| {
-            @R|dev/zacsweers/metro/Provides|() @R|com/squareup/dagger/SingleIn|(value = <getClass>(Q|kotlin/Unit|)) public open fun provideMyService(@R|com/squareup/api/RetrofitAuthenticated|() serviceCreator: R|com/squareup/api/ServiceCreator|, @R|com/squareup/development/FakeMode|() isFakeMode: R|kotlin/Boolean|): R|com/test/MyService|
+            @R|dev/zacsweers/metro/Provides|() @R|dev/zacsweers/metro/SingleIn|(scope = <getClass>(Q|kotlin/Unit|)) public open fun provideMyService(@R|com/squareup/api/RetrofitAuthenticated|() serviceCreator: R|com/squareup/api/ServiceCreator|, @R|com/squareup/development/FakeMode|() isFakeMode: R|kotlin/Boolean|): R|com/test/MyService|
 
             @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) @R|dev/zacsweers/metro/internal/MetroContribution|(scope = <getClass>(Q|kotlin/Unit|)) public abstract interface MetroContributionToKotlinunitdHiVAhs : R|com/test/MyService.ServiceContribution| {
             }

--- a/compiler/src/test/resources/dump/contributesservice/replacedService.fir.kt.txt
+++ b/compiler/src/test/resources/dump/contributesservice/replacedService.fir.kt.txt
@@ -115,7 +115,7 @@ class FakeMyService : MyService {
         return Companion.provideRealMyService(instance = <this>.#instance, serviceCreator = <this>.#serviceCreator.invoke())
       }
 
-      @SingleIn(value = Unit::class)
+      @SingleIn(scope = Unit::class)
       @RealService
       @HiddenFromObjC
       fun mirrorFunction(@RetrofitAuthenticated serviceCreator: ServiceCreator): MyService {
@@ -133,7 +133,7 @@ class FakeMyService : MyService {
     }
 
     @Provides
-    @SingleIn(value = Unit::class)
+    @SingleIn(scope = Unit::class)
     @RealService
     fun provideRealMyService(@RetrofitAuthenticated serviceCreator: ServiceCreator): MyService {
       return serviceCreator.create<MyService>(service = <get-java></* null */>(/* <this> = MyService::class */))
@@ -235,7 +235,7 @@ interface MyService {
         return Companion.provideMyService(instance = <this>.#instance, serviceCreator = <this>.#serviceCreator.invoke(), isFakeMode = <this>.#isFakeMode.invoke())
       }
 
-      @SingleIn(value = Unit::class)
+      @SingleIn(scope = Unit::class)
       @HiddenFromObjC
       fun mirrorFunction(@RetrofitAuthenticated serviceCreator: ServiceCreator, @FakeMode isFakeMode: Boolean): MyService {
         return error(message = "Never called")
@@ -244,7 +244,7 @@ interface MyService {
     }
 
     @Provides
-    @SingleIn(value = Unit::class)
+    @SingleIn(scope = Unit::class)
     fun provideMyService(@RetrofitAuthenticated serviceCreator: ServiceCreator, @FakeMode isFakeMode: Boolean): MyService {
       when {
         isFakeMode -> error(message = "No fake service provided for MyService.")

--- a/compiler/src/test/resources/dump/contributesservice/replacedService.fir.txt
+++ b/compiler/src/test/resources/dump/contributesservice/replacedService.fir.txt
@@ -3,7 +3,7 @@ FILE: replacedService.kt
 
     @R|com/squareup/services/anvil/ContributesService|(scope = <getClass>(Q|kotlin/Unit|)) @R|com/squareup/api/RetrofitAuthenticated|() public abstract interface MyService : R|kotlin/Any| {
         @R|dev/zacsweers/metro/ContributesTo|(scope = <getClass>(Q|kotlin/Unit|)) @R|dev/zacsweers/metro/Origin|(value = <getClass>(Q|com/test/MyService|)) public abstract interface ServiceContribution : R|kotlin/Any| {
-            @R|dev/zacsweers/metro/Provides|() @R|com/squareup/dagger/SingleIn|(value = <getClass>(Q|kotlin/Unit|)) public open fun provideMyService(@R|com/squareup/api/RetrofitAuthenticated|() serviceCreator: R|com/squareup/api/ServiceCreator|, @R|com/squareup/development/FakeMode|() isFakeMode: R|kotlin/Boolean|): R|com/test/MyService|
+            @R|dev/zacsweers/metro/Provides|() @R|dev/zacsweers/metro/SingleIn|(scope = <getClass>(Q|kotlin/Unit|)) public open fun provideMyService(@R|com/squareup/api/RetrofitAuthenticated|() serviceCreator: R|com/squareup/api/ServiceCreator|, @R|com/squareup/development/FakeMode|() isFakeMode: R|kotlin/Boolean|): R|com/test/MyService|
 
             @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) @R|dev/zacsweers/metro/internal/MetroContribution|(scope = <getClass>(Q|kotlin/Unit|)) public abstract interface MetroContributionToKotlinunitdHiVAhs : R|com/test/MyService.ServiceContribution| {
             }
@@ -27,7 +27,7 @@ FILE: replacedService.kt
         }
 
         @R|dev/zacsweers/metro/ContributesTo|(scope = <getClass>(Q|kotlin/Unit|), replaces = <collectionLiteralCall>(<getClass>(Q|com/test/MyService.ServiceContribution|))) @R|dev/zacsweers/metro/Origin|(value = <getClass>(Q|com/test/FakeMyService|)) public abstract interface ServiceContribution : R|kotlin/Any| {
-            @R|dev/zacsweers/metro/Provides|() @R|com/squareup/dagger/SingleIn|(value = <getClass>(Q|kotlin/Unit|)) @R|com/squareup/api/RealService|() public open fun provideRealMyService(@R|com/squareup/api/RetrofitAuthenticated|() serviceCreator: R|com/squareup/api/ServiceCreator|): R|com/test/MyService|
+            @R|dev/zacsweers/metro/Provides|() @R|dev/zacsweers/metro/SingleIn|(scope = <getClass>(Q|kotlin/Unit|)) @R|com/squareup/api/RealService|() public open fun provideRealMyService(@R|com/squareup/api/RetrofitAuthenticated|() serviceCreator: R|com/squareup/api/ServiceCreator|): R|com/test/MyService|
 
             @R|dev/zacsweers/metro/Provides|() public open fun provideMyService(@R|com/squareup/api/RealService|() realService: R|dev/zacsweers/metro/Provider<com/test/MyService>|, fakeService: R|dev/zacsweers/metro/Provider<com/test/FakeMyService>|, @R|com/squareup/development/FakeMode|() isFakeMode: R|kotlin/Boolean|): R|com/test/MyService|
 

--- a/compiler/src/test/resources/dump/contributesservicereleasebuild/contributesServiceReleaseBuild.fir.kt.txt
+++ b/compiler/src/test/resources/dump/contributesservicereleasebuild/contributesServiceReleaseBuild.fir.kt.txt
@@ -59,7 +59,7 @@ interface MyService {
         return Companion.provideMyService(instance = <this>.#instance, serviceCreator = <this>.#serviceCreator.invoke())
       }
 
-      @SingleIn(value = Unit::class)
+      @SingleIn(scope = Unit::class)
       @HiddenFromObjC
       fun mirrorFunction(@RetrofitAuthenticated serviceCreator: ServiceCreator): MyService {
         return error(message = "Never called")
@@ -68,7 +68,7 @@ interface MyService {
     }
 
     @Provides
-    @SingleIn(value = Unit::class)
+    @SingleIn(scope = Unit::class)
     fun provideMyService(@RetrofitAuthenticated serviceCreator: ServiceCreator): MyService {
       return serviceCreator.create<MyService>(service = <get-java></* null */>(/* <this> = MyService::class */))
     }

--- a/compiler/src/test/resources/dump/contributesservicereleasebuild/contributesServiceReleaseBuild.fir.txt
+++ b/compiler/src/test/resources/dump/contributesservicereleasebuild/contributesServiceReleaseBuild.fir.txt
@@ -3,7 +3,7 @@ FILE: contributesServiceReleaseBuild.kt
 
     @R|com/squareup/services/anvil/ContributesService|(scope = <getClass>(Q|kotlin/Unit|)) @R|com/squareup/api/RetrofitAuthenticated|() public abstract interface MyService : R|kotlin/Any| {
         @R|dev/zacsweers/metro/ContributesTo|(scope = <getClass>(Q|kotlin/Unit|)) @R|dev/zacsweers/metro/Origin|(value = <getClass>(Q|com/test/MyService|)) public abstract interface ServiceContribution : R|kotlin/Any| {
-            @R|dev/zacsweers/metro/Provides|() @R|com/squareup/dagger/SingleIn|(value = <getClass>(Q|kotlin/Unit|)) public open fun provideMyService(@R|com/squareup/api/RetrofitAuthenticated|() serviceCreator: R|com/squareup/api/ServiceCreator|): R|com/test/MyService|
+            @R|dev/zacsweers/metro/Provides|() @R|dev/zacsweers/metro/SingleIn|(scope = <getClass>(Q|kotlin/Unit|)) public open fun provideMyService(@R|com/squareup/api/RetrofitAuthenticated|() serviceCreator: R|com/squareup/api/ServiceCreator|): R|com/test/MyService|
 
             @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) @R|dev/zacsweers/metro/internal/MetroContribution|(scope = <getClass>(Q|kotlin/Unit|)) public abstract interface MetroContributionToKotlinunitdHiVAhs : R|com/test/MyService.ServiceContribution| {
             }

--- a/compiler/src/test/resources/dump/developmentappcomponent/developmentAppComponent.fir.txt
+++ b/compiler/src/test/resources/dump/developmentappcomponent/developmentAppComponent.fir.txt
@@ -6,7 +6,7 @@ FILE: developmentAppComponent.kt
             super<R|com/squareup/development/shell/DevelopmentApplication|>()
         }
 
-        @R|dev/zacsweers/metro/DependencyGraph|(scope = <getClass>(Q|com/squareup/dagger/AppScope|)) @R|com/squareup/dagger/SingleIn|(value = <getClass>(Q|com/squareup/dagger/AppScope|)) public abstract interface MetroComponent : R|kotlin/Any| {
+        @R|dev/zacsweers/metro/DependencyGraph|(scope = <getClass>(Q|dev/zacsweers/metro/AppScope|)) @R|dev/zacsweers/metro/SingleIn|(scope = <getClass>(Q|dev/zacsweers/metro/AppScope|)) public abstract interface MetroComponent : R|kotlin/Any| {
             @R|dev/zacsweers/metro/DependencyGraph.Factory|() public abstract interface Factory : R|kotlin/Any|, R|com/squareup/development/shell/DevelopmentAppComponent.Factory| {
                 public abstract fun create(@R|dev/zacsweers/metro/Provides|() application: R|android/app/Application|): R|com/test/MyApp.MetroComponent|
 

--- a/compiler/src/test/resources/dump/developmentappcomponent/excludeLoggedInComponent.fir.txt
+++ b/compiler/src/test/resources/dump/developmentappcomponent/excludeLoggedInComponent.fir.txt
@@ -27,7 +27,7 @@ FILE: module_main_excludeLoggedInComponent.kt
             super<R|com/squareup/development/shell/DevelopmentApplication|>()
         }
 
-        @R|dev/zacsweers/metro/DependencyGraph|(scope = <getClass>(Q|com/squareup/dagger/AppScope|), excludes = <collectionLiteralCall>(<getClass>(Q|com/squareup/development/shell/login/screen/LoginScreenModule|), <getClass>(Q|com/squareup/development/shell/component/DevelopmentLoggedInComponent|))) @R|com/squareup/dagger/SingleIn|(value = <getClass>(Q|com/squareup/dagger/AppScope|)) public abstract interface MetroComponent : R|kotlin/Any| {
+        @R|dev/zacsweers/metro/DependencyGraph|(scope = <getClass>(Q|dev/zacsweers/metro/AppScope|), excludes = <collectionLiteralCall>(<getClass>(Q|com/squareup/development/shell/login/screen/LoginScreenModule|), <getClass>(Q|com/squareup/development/shell/component/DevelopmentLoggedInComponent|))) @R|dev/zacsweers/metro/SingleIn|(scope = <getClass>(Q|dev/zacsweers/metro/AppScope|)) public abstract interface MetroComponent : R|kotlin/Any| {
             @R|dev/zacsweers/metro/DependencyGraph.Factory|() public abstract interface Factory : R|kotlin/Any|, R|com/squareup/development/shell/DevelopmentAppComponent.Factory| {
                 public abstract fun create(@R|dev/zacsweers/metro/Provides|() application: R|android/app/Application|): R|com/test/MyApp.MetroComponent|
 

--- a/compiler/src/test/resources/dump/developmentappcomponent/featureScopeComponent.fir.txt
+++ b/compiler/src/test/resources/dump/developmentappcomponent/featureScopeComponent.fir.txt
@@ -41,7 +41,7 @@ FILE: module_main_featureScopeComponent.kt
             super<R|com/squareup/development/shell/DevelopmentApplication|>()
         }
 
-        @R|dev/zacsweers/metro/DependencyGraph|(scope = <getClass>(Q|com/squareup/dagger/AppScope|)) @R|com/squareup/dagger/SingleIn|(value = <getClass>(Q|com/squareup/dagger/AppScope|)) public abstract interface MetroComponent : R|kotlin/Any| {
+        @R|dev/zacsweers/metro/DependencyGraph|(scope = <getClass>(Q|dev/zacsweers/metro/AppScope|)) @R|dev/zacsweers/metro/SingleIn|(scope = <getClass>(Q|dev/zacsweers/metro/AppScope|)) public abstract interface MetroComponent : R|kotlin/Any| {
             @R|dev/zacsweers/metro/DependencyGraph.Factory|() public abstract interface Factory : R|kotlin/Any|, R|com/squareup/development/shell/DevelopmentAppComponent.Factory| {
                 public abstract fun create(@R|dev/zacsweers/metro/Provides|() application: R|android/app/Application|): R|com/test/MyApp.MetroComponent|
 

--- a/integration-tests/app/src/main/kotlin/com/squareup/test/app/AppRobot.kt
+++ b/integration-tests/app/src/main/kotlin/com/squareup/test/app/AppRobot.kt
@@ -1,8 +1,8 @@
 package com.squareup.test.app
 
 import com.squareup.anvil.extension.ContributesRobot
-import com.squareup.dagger.AppScope
 import com.squareup.instrumentation.robots.compose.ComposeScreenRobot
+import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.Inject
 
 @Inject @ContributesRobot(AppScope::class) class AppRobot : ComposeScreenRobot<AppRobot>()

--- a/integration-tests/app/src/main/kotlin/com/squareup/test/app/AppScoped.kt
+++ b/integration-tests/app/src/main/kotlin/com/squareup/test/app/AppScoped.kt
@@ -1,7 +1,7 @@
 package com.squareup.test.app
 
-import com.squareup.dagger.AppScope
 import com.squareup.dagger.ContributesMultibindingScoped
+import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.Inject
 import mortar.Scoped
 

--- a/integration-tests/app/src/main/kotlin/com/squareup/test/app/AppService.kt
+++ b/integration-tests/app/src/main/kotlin/com/squareup/test/app/AppService.kt
@@ -1,8 +1,8 @@
 package com.squareup.test.app
 
 import com.squareup.api.RetrofitAuthenticated
-import com.squareup.dagger.AppScope
 import com.squareup.services.anvil.ContributesService
+import dev.zacsweers.metro.AppScope
 
 /** A real service that is NOT replaced by a fake. */
 @ContributesService(AppScope::class) @RetrofitAuthenticated interface AppService

--- a/integration-tests/app/src/test/kotlin/com/squareup/test/app/AppGraph.kt
+++ b/integration-tests/app/src/test/kotlin/com/squareup/test/app/AppGraph.kt
@@ -3,15 +3,15 @@ package com.squareup.test.app
 import com.squareup.api.RealService
 import com.squareup.api.RetrofitAuthenticated
 import com.squareup.api.ServiceCreator
-import com.squareup.dagger.AppScope
-import com.squareup.dagger.ForScope
-import com.squareup.dagger.SingleIn
 import com.squareup.development.FakeMode
 import com.squareup.featureflags.FeatureFlag
 import com.squareup.test.app.data.FakeLibService
 import com.squareup.test.lib.LibService
+import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.DependencyGraph
+import dev.zacsweers.metro.ForScope
 import dev.zacsweers.metro.Provides
+import dev.zacsweers.metro.SingleIn
 import mortar.Scoped
 
 @DependencyGraph(AppScope::class)

--- a/integration-tests/app/src/test/kotlin/com/squareup/test/app/data/FakeLibService.kt
+++ b/integration-tests/app/src/test/kotlin/com/squareup/test/app/data/FakeLibService.kt
@@ -1,8 +1,8 @@
 package com.squareup.test.app.data
 
-import com.squareup.dagger.AppScope
 import com.squareup.services.anvil.ContributesService
 import com.squareup.test.lib.LibService
+import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.Inject
 
 /** Fake that replaces [LibService] when fake mode is enabled. */

--- a/integration-tests/app/src/test/kotlin/com/squareup/test/app/data/TestRobot.kt
+++ b/integration-tests/app/src/test/kotlin/com/squareup/test/app/data/TestRobot.kt
@@ -1,8 +1,8 @@
 package com.squareup.test.app.data
 
 import com.squareup.anvil.extension.ContributesRobot
-import com.squareup.dagger.AppScope
 import com.squareup.instrumentation.robots.ScreenRobot
+import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.Inject
 
 @Inject @ContributesRobot(AppScope::class) class TestRobot : ScreenRobot<TestRobot>()

--- a/integration-tests/app/src/test/kotlin/com/squareup/test/app/data/TestScoped.kt
+++ b/integration-tests/app/src/test/kotlin/com/squareup/test/app/data/TestScoped.kt
@@ -1,7 +1,7 @@
 package com.squareup.test.app.data
 
-import com.squareup.dagger.AppScope
 import com.squareup.dagger.ContributesMultibindingScoped
+import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.Inject
 import mortar.Scoped
 

--- a/integration-tests/lib/src/main/kotlin/com/squareup/test/lib/LibRobot.kt
+++ b/integration-tests/lib/src/main/kotlin/com/squareup/test/lib/LibRobot.kt
@@ -1,8 +1,8 @@
 package com.squareup.test.lib
 
 import com.squareup.anvil.extension.ContributesRobot
-import com.squareup.dagger.AppScope
 import com.squareup.instrumentation.robots.ScreenRobot
+import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.Inject
 
 @Inject @ContributesRobot(AppScope::class) class LibRobot : ScreenRobot<LibRobot>()

--- a/integration-tests/lib/src/main/kotlin/com/squareup/test/lib/LibScoped.kt
+++ b/integration-tests/lib/src/main/kotlin/com/squareup/test/lib/LibScoped.kt
@@ -1,7 +1,7 @@
 package com.squareup.test.lib
 
-import com.squareup.dagger.AppScope
 import com.squareup.dagger.ContributesMultibindingScoped
+import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.Inject
 import mortar.Scoped
 

--- a/integration-tests/lib/src/main/kotlin/com/squareup/test/lib/LibService.kt
+++ b/integration-tests/lib/src/main/kotlin/com/squareup/test/lib/LibService.kt
@@ -1,7 +1,7 @@
 package com.squareup.test.lib
 
 import com.squareup.api.RetrofitAuthenticated
-import com.squareup.dagger.AppScope
 import com.squareup.services.anvil.ContributesService
+import dev.zacsweers.metro.AppScope
 
 @ContributesService(AppScope::class) @RetrofitAuthenticated interface LibService

--- a/stubs/src/main/kotlin/com/squareup/dagger/AppScope.kt
+++ b/stubs/src/main/kotlin/com/squareup/dagger/AppScope.kt
@@ -1,3 +1,0 @@
-package com.squareup.dagger
-
-abstract class AppScope private constructor()

--- a/stubs/src/main/kotlin/com/squareup/dagger/ForScope.kt
+++ b/stubs/src/main/kotlin/com/squareup/dagger/ForScope.kt
@@ -1,6 +1,0 @@
-package com.squareup.dagger
-
-import dev.zacsweers.metro.Qualifier
-import kotlin.reflect.KClass
-
-@Qualifier annotation class ForScope(val value: KClass<*>)

--- a/stubs/src/main/kotlin/com/squareup/dagger/SingleIn.kt
+++ b/stubs/src/main/kotlin/com/squareup/dagger/SingleIn.kt
@@ -1,6 +1,0 @@
-package com.squareup.dagger
-
-import dev.zacsweers.metro.Scope
-import kotlin.reflect.KClass
-
-@Scope annotation class SingleIn(val value: KClass<*>)


### PR DESCRIPTION
Remove the local AppScope, ForScope, and SingleIn stubs now that Metro provides the same annotations directly.

Update compiler-generated annotation class IDs to emit Metro's AppScope, ForScope, and SingleIn symbols, including the scope constructor argument used by Metro's ForScope and SingleIn annotations. Refresh affected compiler test sources, FIR dumps, and integration imports to reference dev.zacsweers.metro.