### PR TITLE
Preserve scoped multibinding replacement metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - `@ContributesFeatureFlag` and `@ContributesDynamicConfigurationFlag` now generate `@BindingContainer` objects instead of interfaces for their `@Provides @IntoSet` bindings.
 - `@ContributesService` now generates `@BindingContainer` objects instead of interfaces for its service provider bindings.
 - `@ContributesService` fake services no longer require `@Inject`; non-injectable fake services now get a generated `@Provides` constructor provider, while `@Inject` fake services keep using Metro's normal injection path.
-- `@ContributesMultibindingScoped` no longer requires `@Inject`; non-injectable scoped classes now get a generated `@Provides` constructor provider, while `@Inject` or `@ContributesBinding` scoped classes keep using Metro's normal binding paths.
+- `@ContributesMultibindingScoped` no longer requires `@Inject`; non-injectable scoped classes now get a generated `@Provides` constructor provider, while `@Inject` scoped classes keep using Metro's normal injection path.
 - `@ContributesMultibindingScoped` now annotates its generated contribution interface with `@BindingContainer` and emits constructor `@Provides` functions in the generated companion object.
 
 ### Deprecated
@@ -18,6 +18,8 @@
 ### Removed
 
 ### Fixed
+
+- `@ContributesMultibindingScoped` now generates its concrete constructor provider even when the scoped class also has `@ContributesBinding`, preserving the concrete binding needed by the generated `@Binds` multibinding.
 
 ### Security
 

--- a/README.md
+++ b/README.md
@@ -24,10 +24,9 @@ For detailed descriptions of all annotations including generated output examples
 #### `@ContributesMultibindingScoped(scope: KClass<*>)`
 
 Contributes a class as a scoped multibinding into a Metro dependency graph. The annotated class must
-implement `mortar.Scoped`. If the class is not already injectable with `@Inject` or
-`@ContributesBinding`, the plugin also generates a `@Provides` constructor provider in the generated
-companion object. Classes with multiple constructors must use `@Inject` on the class or on the
-constructor Metro should use.
+implement `mortar.Scoped`. If the class is not already injectable with `@Inject`, the plugin also
+generates a `@Provides` constructor provider in the generated companion object. Classes with
+multiple constructors must use `@Inject` on the class or on the constructor Metro should use.
 
 #### `@ContributesRobot(scope: KClass<*>)`
 

--- a/compiler/api/compiler.api
+++ b/compiler/api/compiler.api
@@ -98,12 +98,14 @@ public final class com/squareup/metro/extensions/robot/ContributesRobotMetroExte
 }
 
 public final class com/squareup/metro/extensions/scoped/ContributesMultibindingScopedFir : dev/zacsweers/metro/compiler/api/fir/MetroFirDeclarationGenerationExtension {
-	public fun <init> (Lorg/jetbrains/kotlin/fir/FirSession;)V
+	public fun <init> (Lorg/jetbrains/kotlin/fir/FirSession;Ldev/zacsweers/metro/compiler/compat/CompatContext;)V
 	public fun generateConstructors (Lorg/jetbrains/kotlin/fir/extensions/DeclarationGenerationContext$Member;)Ljava/util/List;
 	public fun generateNestedClassLikeDeclaration (Lorg/jetbrains/kotlin/fir/symbols/impl/FirClassSymbol;Lorg/jetbrains/kotlin/name/Name;Lorg/jetbrains/kotlin/fir/extensions/DeclarationGenerationContext$Nested;)Lorg/jetbrains/kotlin/fir/symbols/impl/FirClassLikeSymbol;
+	public fun generateTopLevelClassLikeDeclaration (Lorg/jetbrains/kotlin/name/ClassId;)Lorg/jetbrains/kotlin/fir/symbols/impl/FirClassLikeSymbol;
 	public fun getCallableNamesForClass (Lorg/jetbrains/kotlin/fir/symbols/impl/FirClassSymbol;Lorg/jetbrains/kotlin/fir/extensions/DeclarationGenerationContext$Member;)Ljava/util/Set;
 	public fun getContributionHints ()Ljava/util/List;
 	public fun getNestedClassifiersNames (Lorg/jetbrains/kotlin/fir/symbols/impl/FirClassSymbol;Lorg/jetbrains/kotlin/fir/extensions/DeclarationGenerationContext$Nested;)Ljava/util/Set;
+	public fun getTopLevelClassIds ()Ljava/util/Set;
 	public fun registerPredicates (Lorg/jetbrains/kotlin/fir/extensions/FirDeclarationPredicateRegistrar;)V
 }
 

--- a/compiler/src/main/kotlin/com/squareup/metro/extensions/ClassIds.kt
+++ b/compiler/src/main/kotlin/com/squareup/metro/extensions/ClassIds.kt
@@ -46,6 +46,12 @@ internal object ClassIds {
 
   val SINGLE_IN = ClassId(FqName("dev.zacsweers.metro"), Name.identifier("SingleIn"))
 
+  val METRO_SCOPE = ClassId(FqName("dev.zacsweers.metro"), Name.identifier("Scope"))
+
+  val JAVAX_SCOPE = ClassId(FqName("javax.inject"), Name.identifier("Scope"))
+
+  val SCOPE_CLASS_IDS = setOf(METRO_SCOPE, JAVAX_SCOPE)
+
   val PROVIDER = ClassId(FqName("dev.zacsweers.metro"), Name.identifier("Provider"))
 
   val SERVICE_CREATOR = ClassId(FqName("com.squareup.api"), Name.identifier("ServiceCreator"))

--- a/compiler/src/main/kotlin/com/squareup/metro/extensions/fir/FirHelpers.kt
+++ b/compiler/src/main/kotlin/com/squareup/metro/extensions/fir/FirHelpers.kt
@@ -3,6 +3,7 @@ package com.squareup.metro.extensions.fir
 import com.squareup.metro.extensions.ArgNames
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.declarations.DirectDeclarationsAccess
+import org.jetbrains.kotlin.fir.declarations.FirValueParameter
 import org.jetbrains.kotlin.fir.declarations.toAnnotationClassIdSafe
 import org.jetbrains.kotlin.fir.expressions.FirAnnotation
 import org.jetbrains.kotlin.fir.expressions.FirAnnotationCall
@@ -39,6 +40,15 @@ import org.jetbrains.kotlin.fir.symbols.impl.FirConstructorSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirRegularClassSymbol
 import org.jetbrains.kotlin.fir.toFirResolvedTypeRef
 import org.jetbrains.kotlin.fir.types.ConeKotlinType
+import org.jetbrains.kotlin.fir.types.ConeStarProjection
+import org.jetbrains.kotlin.fir.types.ConeTypeProjection
+import org.jetbrains.kotlin.fir.types.FirResolvedTypeRef
+import org.jetbrains.kotlin.fir.types.FirStarProjection
+import org.jetbrains.kotlin.fir.types.FirTypeProjection
+import org.jetbrains.kotlin.fir.types.FirTypeProjectionWithVariance
+import org.jetbrains.kotlin.fir.types.FirTypeRef
+import org.jetbrains.kotlin.fir.types.FirUserTypeRef
+import org.jetbrains.kotlin.fir.types.coneType
 import org.jetbrains.kotlin.fir.types.impl.ConeClassLikeTypeImpl
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
@@ -228,6 +238,175 @@ internal fun extractScopeClassId(
     }
     else -> null
   }
+}
+
+internal fun resolveValueParameterTypeRef(
+  parameter: FirValueParameter,
+  ownerSymbol: FirClassLikeSymbol<*>,
+  session: FirSession,
+): FirTypeRef {
+  val returnTypeRef = parameter.returnTypeRef
+  if (returnTypeRef is FirResolvedTypeRef) return returnTypeRef
+
+  val file = session.firProvider.getFirClassifierContainerFileIfAny(ownerSymbol)
+  val scopes =
+    if (file != null) {
+      createImportingScopes(file, session, ScopeSession())
+    } else {
+      emptyList()
+    }
+
+  val resolutionFailure =
+    runCatching {
+        session.typeResolver
+          .resolveType(
+            typeRef = returnTypeRef,
+            configuration =
+              TypeResolutionConfiguration(
+                scopes = scopes,
+                containingClassDeclarations = emptyList(),
+                useSiteFile = file,
+              ),
+            areBareTypesAllowed = true,
+            isOperandOfIsOperator = false,
+            resolveDeprecations = false,
+            supertypeSupplier = SupertypeSupplier.Default,
+            expandTypeAliases = false,
+          )
+          .type
+          .toFirResolvedTypeRef()
+      }
+      .fold(
+        onSuccess = {
+          return it
+        },
+        onFailure = { it },
+      )
+
+  resolvedUserTypeRefByClassId(returnTypeRef, ownerSymbol, session)?.let {
+    return it.toFirResolvedTypeRef()
+  }
+
+  throw resolutionFailure
+}
+
+private fun resolvedUserTypeRefByClassId(
+  typeRef: FirTypeRef,
+  ownerSymbol: FirClassLikeSymbol<*>,
+  session: FirSession,
+): ConeKotlinType? {
+  val userTypeRef = typeRef as? FirUserTypeRef ?: return null
+  val classId = resolveClassIdFromUserTypeRef(userTypeRef, ownerSymbol, session) ?: return null
+  val typeArguments =
+    userTypeRef.qualifier
+      .lastOrNull()
+      ?.typeArgumentList
+      ?.typeArguments
+      .orEmpty()
+      .map { projection -> resolveTypeProjection(projection, ownerSymbol, session) ?: return null }
+      .toTypedArray()
+  return ConeClassLikeTypeImpl(
+    ConeClassLikeLookupTagImpl(classId),
+    typeArguments,
+    isMarkedNullable = userTypeRef.isMarkedNullable,
+  )
+}
+
+private fun resolveTypeProjection(
+  projection: FirTypeProjection,
+  ownerSymbol: FirClassLikeSymbol<*>,
+  session: FirSession,
+): ConeTypeProjection? {
+  return when (projection) {
+    is FirStarProjection -> ConeStarProjection
+    is FirTypeProjectionWithVariance ->
+      resolveTypeRefToConeType(projection.typeRef, ownerSymbol, session)
+    else -> null
+  }
+}
+
+private fun resolveTypeRefToConeType(
+  typeRef: FirTypeRef,
+  ownerSymbol: FirClassLikeSymbol<*>,
+  session: FirSession,
+): ConeKotlinType? {
+  if (typeRef is FirResolvedTypeRef) return typeRef.coneType
+
+  val file = session.firProvider.getFirClassifierContainerFileIfAny(ownerSymbol)
+  val scopes =
+    if (file != null) {
+      createImportingScopes(file, session, ScopeSession())
+    } else {
+      emptyList()
+    }
+
+  return runCatching {
+      session.typeResolver
+        .resolveType(
+          typeRef = typeRef,
+          configuration =
+            TypeResolutionConfiguration(
+              scopes = scopes,
+              containingClassDeclarations = emptyList(),
+              useSiteFile = file,
+            ),
+          areBareTypesAllowed = true,
+          isOperandOfIsOperator = false,
+          resolveDeprecations = false,
+          supertypeSupplier = SupertypeSupplier.Default,
+          expandTypeAliases = false,
+        )
+        .type
+    }
+    .getOrNull() ?: resolvedUserTypeRefByClassId(typeRef, ownerSymbol, session)
+}
+
+private fun resolveClassIdFromUserTypeRef(
+  typeRef: FirUserTypeRef,
+  ownerSymbol: FirClassLikeSymbol<*>,
+  session: FirSession,
+): ClassId? {
+  val names = typeRef.qualifier.map { it.name }
+  if (names.isEmpty()) return null
+
+  val file = session.firProvider.getFirClassifierContainerFileIfAny(ownerSymbol)
+  val firstName = names.first()
+  val explicitImport =
+    file?.imports?.firstNotNullOfOrNull { import ->
+      if (import.isAllUnder) return@firstNotNullOfOrNull null
+      val importedFqName = import.importedFqName ?: return@firstNotNullOfOrNull null
+      if (importedFqName.shortName() == firstName) {
+        ClassId(importedFqName.parent(), names.toFqName(), false)
+      } else {
+        null
+      }
+    }
+  if (explicitImport != null) return explicitImport
+
+  if (names.size > 1 && firstName.asString().firstOrNull()?.isLowerCase() == true) {
+    return ClassId(names.dropLast(1).toFqName(), names.takeLast(1).toFqName(), false)
+  }
+
+  val candidates = buildList {
+    add(ClassId(ownerSymbol.classId.packageFqName, names.toFqName(), false))
+    add(ClassId(FqName("kotlin.collections"), names.toFqName(), false))
+
+    file?.imports?.forEach { import ->
+      if (!import.isAllUnder) return@forEach
+      val importedFqName = import.importedFqName ?: return@forEach
+      add(ClassId(importedFqName, names.toFqName(), false))
+    }
+
+    add(ClassId(FqName("kotlin"), names.toFqName(), false))
+  }
+
+  return candidates.firstOrNull { candidate ->
+    session.symbolProvider.getClassLikeSymbolByClassId(candidate) != null
+  } ?: candidates.first()
+}
+
+private fun List<Name>.toFqName(): FqName {
+  return if (isEmpty()) FqName.ROOT else FqName(joinToString(".") { it.asString() })
 }
 
 /**

--- a/compiler/src/main/kotlin/com/squareup/metro/extensions/robot/ContributesRobotFir.kt
+++ b/compiler/src/main/kotlin/com/squareup/metro/extensions/robot/ContributesRobotFir.kt
@@ -9,6 +9,7 @@ import com.squareup.metro.extensions.fir.buildClassExpression
 import com.squareup.metro.extensions.fir.extractScopeArgument
 import com.squareup.metro.extensions.fir.extractScopeClassId
 import com.squareup.metro.extensions.fir.hasAnnotation
+import com.squareup.metro.extensions.fir.resolveValueParameterTypeRef
 import dev.zacsweers.metro.compiler.MetroOptions
 import dev.zacsweers.metro.compiler.api.fir.MetroFirDeclarationGenerationExtension
 import dev.zacsweers.metro.compiler.compat.CompatContext
@@ -19,7 +20,6 @@ import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.declarations.DirectDeclarationsAccess
 import org.jetbrains.kotlin.fir.declarations.FirFunction
 import org.jetbrains.kotlin.fir.declarations.FirResolvePhase
-import org.jetbrains.kotlin.fir.declarations.FirValueParameter
 import org.jetbrains.kotlin.fir.declarations.builder.buildNamedFunction
 import org.jetbrains.kotlin.fir.declarations.builder.buildRegularClass
 import org.jetbrains.kotlin.fir.declarations.builder.buildValueParameter
@@ -36,14 +36,8 @@ import org.jetbrains.kotlin.fir.extensions.NestedClassGenerationContext
 import org.jetbrains.kotlin.fir.extensions.predicateBasedProvider
 import org.jetbrains.kotlin.fir.moduleData
 import org.jetbrains.kotlin.fir.references.builder.buildResolvedNamedReference
-import org.jetbrains.kotlin.fir.resolve.ScopeSession
-import org.jetbrains.kotlin.fir.resolve.SupertypeSupplier
-import org.jetbrains.kotlin.fir.resolve.TypeResolutionConfiguration
 import org.jetbrains.kotlin.fir.resolve.defaultType
-import org.jetbrains.kotlin.fir.resolve.providers.firProvider
 import org.jetbrains.kotlin.fir.resolve.providers.symbolProvider
-import org.jetbrains.kotlin.fir.resolve.typeResolver
-import org.jetbrains.kotlin.fir.scopes.createImportingScopes
 import org.jetbrains.kotlin.fir.scopes.kotlinScopeProvider
 import org.jetbrains.kotlin.fir.symbols.FirBasedSymbol
 import org.jetbrains.kotlin.fir.symbols.SymbolInternals
@@ -56,8 +50,6 @@ import org.jetbrains.kotlin.fir.symbols.impl.FirRegularClassSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirValueParameterSymbol
 import org.jetbrains.kotlin.fir.toEffectiveVisibility
 import org.jetbrains.kotlin.fir.toFirResolvedTypeRef
-import org.jetbrains.kotlin.fir.types.FirResolvedTypeRef
-import org.jetbrains.kotlin.fir.types.FirTypeRef
 import org.jetbrains.kotlin.fir.types.impl.ConeClassLikeTypeImpl
 import org.jetbrains.kotlin.name.CallableId
 import org.jetbrains.kotlin.name.ClassId
@@ -205,7 +197,7 @@ public class ContributesRobotFir(session: FirSession) :
           resolvePhase = FirResolvePhase.BODY_RESOLVE
           moduleData = session.moduleData
           origin = ContributesRobotGeneratorKey.origin
-          returnTypeRef = resolveParameterTypeRef(parameter, robotSymbol)
+          returnTypeRef = resolveValueParameterTypeRef(parameter, robotSymbol, session)
           this.name = parameter.name
           symbol = FirValueParameterSymbol()
           containingDeclarationSymbol = functionSymbol
@@ -308,40 +300,6 @@ public class ContributesRobotFir(session: FirSession) :
   private fun robotProviderFunctionName(contributorClassId: ClassId): Name {
     val fileName = contributorClassId.relativeClassName.asString().replace('.', '_') + "Component"
     return Name.identifier("provide$fileName")
-  }
-
-  private fun resolveParameterTypeRef(
-    parameter: FirValueParameter,
-    ownerSymbol: FirRegularClassSymbol,
-  ): FirTypeRef {
-    val returnTypeRef = parameter.returnTypeRef
-    if (returnTypeRef is FirResolvedTypeRef) return returnTypeRef
-
-    val file = session.firProvider.getFirClassifierContainerFileIfAny(ownerSymbol)
-    val scopes =
-      if (file != null) {
-        createImportingScopes(file, session, ScopeSession())
-      } else {
-        emptyList()
-      }
-
-    return session.typeResolver
-      .resolveType(
-        typeRef = returnTypeRef,
-        configuration =
-          TypeResolutionConfiguration(
-            scopes = scopes,
-            containingClassDeclarations = emptyList(),
-            useSiteFile = file,
-          ),
-        areBareTypesAllowed = true,
-        isOperandOfIsOperator = false,
-        resolveDeprecations = false,
-        supertypeSupplier = SupertypeSupplier.Default,
-        expandTypeAliases = false,
-      )
-      .type
-      .toFirResolvedTypeRef()
   }
 
   private fun fqcnBasedAccessorName(contributorClassId: ClassId): String {

--- a/compiler/src/main/kotlin/com/squareup/metro/extensions/scoped/ContributesMultibindingScopedFir.kt
+++ b/compiler/src/main/kotlin/com/squareup/metro/extensions/scoped/ContributesMultibindingScopedFir.kt
@@ -6,46 +6,48 @@ import com.squareup.metro.extensions.ClassIds
 import com.squareup.metro.extensions.Keys.ContributesMultibindingScopedGeneratorKey
 import com.squareup.metro.extensions.fir.buildAnnotationCallWithScope
 import com.squareup.metro.extensions.fir.buildClassExpression
-import com.squareup.metro.extensions.fir.extractScopeArgument
 import com.squareup.metro.extensions.fir.extractScopeClassId
 import com.squareup.metro.extensions.fir.hasAnnotation
+import com.squareup.metro.extensions.fir.resolveValueParameterTypeRef
 import dev.zacsweers.metro.compiler.MetroOptions
 import dev.zacsweers.metro.compiler.api.fir.MetroFirDeclarationGenerationExtension
 import dev.zacsweers.metro.compiler.compat.CompatContext
+import org.jetbrains.kotlin.KtFakeSourceElementKind
+import org.jetbrains.kotlin.KtSourceElement
 import org.jetbrains.kotlin.descriptors.ClassKind
 import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.descriptors.Visibilities
+import org.jetbrains.kotlin.descriptors.annotations.AnnotationUseSiteTarget
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.declarations.DirectDeclarationsAccess
 import org.jetbrains.kotlin.fir.declarations.FirDeclaration
 import org.jetbrains.kotlin.fir.declarations.FirResolvePhase
-import org.jetbrains.kotlin.fir.declarations.FirValueParameter
 import org.jetbrains.kotlin.fir.declarations.builder.buildNamedFunction
 import org.jetbrains.kotlin.fir.declarations.builder.buildRegularClass
 import org.jetbrains.kotlin.fir.declarations.builder.buildValueParameter
 import org.jetbrains.kotlin.fir.declarations.impl.FirResolvedDeclarationStatusImpl
 import org.jetbrains.kotlin.fir.declarations.origin
 import org.jetbrains.kotlin.fir.declarations.toAnnotationClassIdSafe
+import org.jetbrains.kotlin.fir.expressions.FirAnnotation
+import org.jetbrains.kotlin.fir.expressions.FirAnnotationArgumentMapping
 import org.jetbrains.kotlin.fir.expressions.FirAnnotationCall
 import org.jetbrains.kotlin.fir.expressions.FirAnnotationResolvePhase
+import org.jetbrains.kotlin.fir.expressions.FirArgumentList
 import org.jetbrains.kotlin.fir.expressions.FirExpression
+import org.jetbrains.kotlin.fir.expressions.UnresolvedExpressionTypeAccess
 import org.jetbrains.kotlin.fir.expressions.builder.buildAnnotationArgumentMapping
 import org.jetbrains.kotlin.fir.expressions.builder.buildAnnotationCall
+import org.jetbrains.kotlin.fir.extensions.ExperimentalTopLevelDeclarationsGenerationApi
 import org.jetbrains.kotlin.fir.extensions.FirDeclarationPredicateRegistrar
 import org.jetbrains.kotlin.fir.extensions.MemberGenerationContext
 import org.jetbrains.kotlin.fir.extensions.NestedClassGenerationContext
 import org.jetbrains.kotlin.fir.extensions.predicateBasedProvider
 import org.jetbrains.kotlin.fir.moduleData
-import org.jetbrains.kotlin.fir.plugin.createDefaultPrivateConstructor
+import org.jetbrains.kotlin.fir.plugin.createConstructor
+import org.jetbrains.kotlin.fir.references.FirReference
 import org.jetbrains.kotlin.fir.references.builder.buildResolvedNamedReference
-import org.jetbrains.kotlin.fir.resolve.ScopeSession
-import org.jetbrains.kotlin.fir.resolve.SupertypeSupplier
-import org.jetbrains.kotlin.fir.resolve.TypeResolutionConfiguration
 import org.jetbrains.kotlin.fir.resolve.defaultType
-import org.jetbrains.kotlin.fir.resolve.providers.firProvider
 import org.jetbrains.kotlin.fir.resolve.providers.symbolProvider
-import org.jetbrains.kotlin.fir.resolve.typeResolver
-import org.jetbrains.kotlin.fir.scopes.createImportingScopes
 import org.jetbrains.kotlin.fir.scopes.kotlinScopeProvider
 import org.jetbrains.kotlin.fir.symbols.FirBasedSymbol
 import org.jetbrains.kotlin.fir.symbols.SymbolInternals
@@ -58,9 +60,12 @@ import org.jetbrains.kotlin.fir.symbols.impl.FirRegularClassSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirValueParameterSymbol
 import org.jetbrains.kotlin.fir.toEffectiveVisibility
 import org.jetbrains.kotlin.fir.toFirResolvedTypeRef
-import org.jetbrains.kotlin.fir.types.FirResolvedTypeRef
+import org.jetbrains.kotlin.fir.types.ConeKotlinType
+import org.jetbrains.kotlin.fir.types.FirTypeProjection
 import org.jetbrains.kotlin.fir.types.FirTypeRef
 import org.jetbrains.kotlin.fir.types.impl.ConeClassLikeTypeImpl
+import org.jetbrains.kotlin.fir.visitors.FirTransformer
+import org.jetbrains.kotlin.fir.visitors.FirVisitor
 import org.jetbrains.kotlin.name.CallableId
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.Name
@@ -109,28 +114,101 @@ private const val SCOPED_PROVIDER_FUNCTION_NAME = "provideContributedMultibindin
  * `getCallableNamesForClass`/`generateFunctions`) so Metro can see it when deciding what nested
  * classes to generate.
  */
-public class ContributesMultibindingScopedFir(session: FirSession) :
-  MetroFirDeclarationGenerationExtension(session) {
+public class ContributesMultibindingScopedFir(
+  session: FirSession,
+  private val compatContext: CompatContext,
+) : MetroFirDeclarationGenerationExtension(session) {
+
+  private val annotatedScopedClasses by lazy {
+    session.predicateBasedProvider
+      .getSymbolsByPredicate(ContributesMultibindingScopedIds.PREDICATE)
+      .filterIsInstance<FirRegularClassSymbol>()
+      .toList()
+  }
+
+  private val generatedHolderClassIds by lazy {
+    annotatedScopedClasses.associateBy { classSymbol ->
+      ContributesMultibindingScopedIds.holderClassId(classSymbol.classId)
+    }
+  }
 
   override fun FirDeclarationPredicateRegistrar.registerPredicates() {
     register(ContributesMultibindingScopedIds.PREDICATE)
+  }
+
+  @ExperimentalTopLevelDeclarationsGenerationApi
+  override fun getTopLevelClassIds(): Set<ClassId> {
+    return generatedHolderClassIds.keys
+  }
+
+  @ExperimentalTopLevelDeclarationsGenerationApi
+  override fun generateTopLevelClassLikeDeclaration(classId: ClassId): FirClassLikeSymbol<*>? {
+    val scopedSymbol = generatedHolderClassIds[classId] ?: return null
+    val scopeClassId =
+      extractScopeClassId(
+        scopedSymbol,
+        ContributesMultibindingScopedIds.CONTRIBUTES_MULTIBINDING_SCOPED_CLASS_ID,
+        session,
+      ) ?: return null
+    val scopeSymbol =
+      session.symbolProvider.getClassLikeSymbolByClassId(scopeClassId) as? FirClassSymbol<*>
+        ?: return null
+    val scopeArg = buildClassExpression(scopeSymbol, session)
+    val classSymbol = FirRegularClassSymbol(classId)
+
+    return buildRegularClass {
+        resolvePhase = FirResolvePhase.BODY_RESOLVE
+        moduleData = session.moduleData
+        origin = ContributesMultibindingScopedGeneratorKey.origin
+        classKind = ClassKind.INTERFACE
+        scopeProvider = session.kotlinScopeProvider
+        name = classId.shortClassName
+        symbol = classSymbol
+        status =
+          FirResolvedDeclarationStatusImpl(
+            Visibilities.Public,
+            Modality.ABSTRACT,
+            Visibilities.Public.toEffectiveVisibility(scopedSymbol, forClass = true),
+          )
+        superTypeRefs += session.builtinTypes.anyType
+        annotations +=
+          NonAcceptingAnnotationCall(
+            compatContext,
+            buildAnnotationCallWithScope(
+              ClassIds.CONTRIBUTES_TO,
+              ArgNames.SCOPE,
+              scopeArg,
+              classSymbol,
+              session,
+            ),
+            classSymbol,
+          )
+        annotations += buildSimpleAnnotationCall(ClassIds.BINDING_CONTAINER, classSymbol)
+        annotations +=
+          NonAcceptingAnnotationCall(
+            compatContext,
+            buildAnnotationCallWithScope(
+              ClassIds.ORIGIN,
+              ArgNames.VALUE,
+              buildClassExpression(scopedSymbol, session),
+              classSymbol,
+              session,
+            ),
+            classSymbol,
+          )
+      }
+      .symbol
   }
 
   override fun getNestedClassifiersNames(
     classSymbol: FirClassSymbol<*>,
     context: NestedClassGenerationContext,
   ): Set<Name> {
-    if (needsGeneratedProvidesCompanion(classSymbol)) {
-      return setOf(SpecialNames.DEFAULT_NAME_FOR_COMPANION_OBJECT)
-    }
-    if (
-      hasAnnotation(
-        classSymbol,
-        ContributesMultibindingScopedIds.CONTRIBUTES_MULTIBINDING_SCOPED_CLASS_ID,
-        session,
-      )
-    ) {
-      return setOf(ContributesMultibindingScopedIds.NESTED_INTERFACE_NAME)
+    generatedHolderClassIds[classSymbol.classId]?.let { scopedSymbol ->
+      return buildSet {
+        add(ContributesMultibindingScopedIds.NESTED_INTERFACE_NAME)
+        if (needsProvidesFunction(scopedSymbol)) add(SpecialNames.DEFAULT_NAME_FOR_COMPANION_OBJECT)
+      }
     }
     return emptySet()
   }
@@ -141,83 +219,76 @@ public class ContributesMultibindingScopedFir(session: FirSession) :
     context: NestedClassGenerationContext,
   ): FirClassLikeSymbol<*>? {
     if (name == SpecialNames.DEFAULT_NAME_FOR_COMPANION_OBJECT) {
-      val scopedSymbol = scopedSymbolForGeneratedContribution(owner) ?: return null
+      val scopedSymbol = generatedHolderClassIds[owner.classId] ?: return null
       if (!needsProvidesFunction(scopedSymbol)) return null
       val companionClassId = owner.classId.createNestedClassId(name)
-      val providesFunction = buildProvidesFunction(companionClassId, scopedSymbol) ?: return null
-      return buildProvidesCompanionObject(companionClassId, owner, providesFunction)
+      val providerFunctions = buildList {
+        buildProvidesFunction(companionClassId, scopedSymbol)?.let(::add)
+      }
+      return buildProvidesCompanionObject(companionClassId, owner, providerFunctions)
     }
 
     if (name != ContributesMultibindingScopedIds.NESTED_INTERFACE_NAME) return null
-    if (
-      !hasAnnotation(
-        owner,
-        ContributesMultibindingScopedIds.CONTRIBUTES_MULTIBINDING_SCOPED_CLASS_ID,
-        session,
-      )
-    )
-      return null
-    val scopeArg =
-      extractScopeArgument(
-        owner,
+    val scopedSymbol = generatedHolderClassIds[owner.classId] ?: return null
+    val scopeClassId =
+      extractScopeClassId(
+        scopedSymbol,
         ContributesMultibindingScopedIds.CONTRIBUTES_MULTIBINDING_SCOPED_CLASS_ID,
         session,
       ) ?: return null
+    val scopeSymbol =
+      session.symbolProvider.getClassLikeSymbolByClassId(scopeClassId) as? FirClassSymbol<*>
+        ?: return null
+    val scopeArg = buildClassExpression(scopeSymbol, session)
+    val shouldGenerateBinds = !hasLegacyScopedProviders(scopedSymbol)
 
     val nestedClassId = owner.classId.createNestedClassId(name)
     val classSymbol = FirRegularClassSymbol(nestedClassId)
-
-    // Build the @Binds function and add it directly to the class declarations.
-    // This makes it visible to Metro's getNestedClassifiersNames (which checks for @Binds
-    // functions to decide whether to generate BindsMirror).
-    val bindsFunction = buildBindsFunction(nestedClassId, owner, scopeArg)
-
-    val klass = buildRegularClass {
-      resolvePhase = FirResolvePhase.BODY_RESOLVE
-      moduleData = session.moduleData
-      origin = ContributesMultibindingScopedGeneratorKey.origin
-      source = owner.source
-      classKind = ClassKind.INTERFACE
-      scopeProvider = session.kotlinScopeProvider
-      this.name = nestedClassId.shortClassName
-      symbol = classSymbol
-      status =
-        FirResolvedDeclarationStatusImpl(
-          Visibilities.Public,
-          Modality.ABSTRACT,
-          Visibilities.Public.toEffectiveVisibility(owner, forClass = true),
-        )
-      superTypeRefs += session.builtinTypes.anyType
-      annotations +=
-        buildAnnotationCallWithScope(
-          ClassIds.CONTRIBUTES_TO,
-          ArgNames.SCOPE,
-          scopeArg,
-          owner,
-          session,
-        )
-      annotations += buildSimpleAnnotationCall(ClassIds.BINDING_CONTAINER, classSymbol)
-      // @Origin(OwnerClass::class) so Metro can trace this contribution back to the
-      // outer class for replaces/excludes in multi-compilation scenarios.
-      annotations +=
-        buildAnnotationCallWithScope(
-          ClassIds.ORIGIN,
-          ArgNames.VALUE,
-          buildClassExpression(owner, session),
-          classSymbol,
-          session,
-        )
-      // Add the function directly to the class declarations
-      declarations += bindsFunction
+    val declarations = buildList {
+      if (shouldGenerateBinds) {
+        add(buildBindsFunction(nestedClassId, scopedSymbol, scopeArg))
+      }
     }
 
-    return klass.symbol
+    return buildRegularClass {
+        resolvePhase = FirResolvePhase.BODY_RESOLVE
+        moduleData = session.moduleData
+        origin = ContributesMultibindingScopedGeneratorKey.origin
+        classKind = ClassKind.INTERFACE
+        scopeProvider = session.kotlinScopeProvider
+        this.name = nestedClassId.shortClassName
+        symbol = classSymbol
+        status =
+          FirResolvedDeclarationStatusImpl(
+            Visibilities.Public,
+            Modality.ABSTRACT,
+            Visibilities.Public.toEffectiveVisibility(owner, forClass = true),
+          )
+        superTypeRefs += session.builtinTypes.anyType
+        annotations +=
+          buildAnnotationCallWithScope(
+            ClassIds.CONTRIBUTES_TO,
+            ArgNames.SCOPE,
+            scopeArg,
+            classSymbol,
+            session,
+          )
+        annotations += buildSimpleAnnotationCall(ClassIds.BINDING_CONTAINER, classSymbol)
+        annotations +=
+          buildAnnotationCallWithScope(
+            ClassIds.ORIGIN,
+            ArgNames.VALUE,
+            buildClassExpression(scopedSymbol, session),
+            classSymbol,
+            session,
+          )
+        this.declarations += declarations
+      }
+      .symbol
   }
 
   override fun getContributionHints(): List<ContributionHint> {
-    return session.predicateBasedProvider
-      .getSymbolsByPredicate(ContributesMultibindingScopedIds.PREDICATE)
-      .filterIsInstance<FirRegularClassSymbol>()
+    return annotatedScopedClasses
       .mapNotNull { classSymbol ->
         val scopeClassId =
           extractScopeClassId(
@@ -225,19 +296,31 @@ public class ContributesMultibindingScopedFir(session: FirSession) :
             ContributesMultibindingScopedIds.CONTRIBUTES_MULTIBINDING_SCOPED_CLASS_ID,
             session,
           ) ?: return@mapNotNull null
-        val nestedInterfaceClassId =
-          classSymbol.classId.createNestedClassId(
-            ContributesMultibindingScopedIds.NESTED_INTERFACE_NAME
+        buildList<ContributionHint> {
+          add(
+            ContributionHint(
+              contributingClassId =
+                ContributesMultibindingScopedIds.holderClassId(classSymbol.classId),
+              scope = scopeClassId,
+            )
           )
-        ContributionHint(contributingClassId = nestedInterfaceClassId, scope = scopeClassId)
+          add(
+            ContributionHint(
+              contributingClassId =
+                ContributesMultibindingScopedIds.contributionClassId(classSymbol.classId),
+              scope = scopeClassId,
+            )
+          )
+        }
       }
+      .flatten()
   }
 
   override fun getCallableNamesForClass(
     classSymbol: FirClassSymbol<*>,
     context: MemberGenerationContext,
   ): Set<Name> {
-    return if (isGeneratedProvidesCompanion(classSymbol)) {
+    return if (isGeneratedHolderCompanion(classSymbol)) {
       setOf(SpecialNames.INIT)
     } else {
       emptySet()
@@ -245,9 +328,16 @@ public class ContributesMultibindingScopedFir(session: FirSession) :
   }
 
   override fun generateConstructors(context: MemberGenerationContext): List<FirConstructorSymbol> {
-    return if (isGeneratedProvidesCompanion(context.owner)) {
+    return if (isGeneratedHolderCompanion(context.owner)) {
       listOf(
-        createDefaultPrivateConstructor(context.owner, ContributesMultibindingScopedGeneratorKey)
+        createConstructor(
+            context.owner,
+            ContributesMultibindingScopedGeneratorKey,
+            isPrimary = true,
+            generateDelegatedNoArgConstructorCall = true,
+          ) {
+            visibility = Visibilities.Private
+          }
           .symbol
       )
     } else {
@@ -323,14 +413,13 @@ public class ContributesMultibindingScopedFir(session: FirSession) :
   private fun buildProvidesCompanionObject(
     classId: ClassId,
     outerOwner: FirClassSymbol<*>,
-    providesFunction: FirDeclaration,
+    providesFunctions: List<FirDeclaration>,
   ): FirClassLikeSymbol<*> {
     val classSymbol = FirRegularClassSymbol(classId)
     buildRegularClass {
       resolvePhase = FirResolvePhase.BODY_RESOLVE
       moduleData = session.moduleData
       origin = ContributesMultibindingScopedGeneratorKey.origin
-      source = outerOwner.source
       classKind = ClassKind.OBJECT
       scopeProvider = session.kotlinScopeProvider
       name = SpecialNames.DEFAULT_NAME_FOR_COMPANION_OBJECT
@@ -343,14 +432,14 @@ public class ContributesMultibindingScopedFir(session: FirSession) :
           )
           .apply { isCompanion = true }
       superTypeRefs += session.builtinTypes.anyType
-      declarations += providesFunction
+      declarations += providesFunctions
     }
     return classSymbol
   }
 
   /**
    * Build the `@Provides` function that constructs the scoped class when it is not already
-   * injectable and no `@ContributesBinding` self-provider is expected from Metro.
+   * injectable.
    *
    * Generates: `@Provides fun provideContributedMultibindingScoped(dependency: Dependency):
    * MyScoped`
@@ -395,7 +484,7 @@ public class ContributesMultibindingScopedFir(session: FirSession) :
           resolvePhase = FirResolvePhase.BODY_RESOLVE
           moduleData = session.moduleData
           origin = ContributesMultibindingScopedGeneratorKey.origin
-          returnTypeRef = resolveParameterTypeRef(parameter, scopedSymbol)
+          returnTypeRef = resolveValueParameterTypeRef(parameter, scopedSymbol, session)
           this.name = parameter.name
           symbol = FirValueParameterSymbol()
           containingDeclarationSymbol = functionSymbol
@@ -404,6 +493,7 @@ public class ContributesMultibindingScopedFir(session: FirSession) :
       }
 
       annotations += buildSimpleAnnotationCall(ClassIds.PROVIDES, functionSymbol)
+      annotations += buildScopeAnnotationCopies(scopedSymbol, functionSymbol)
     }
   }
 
@@ -417,73 +507,45 @@ public class ContributesMultibindingScopedFir(session: FirSession) :
       }
   }
 
-  private fun hasContributesBindingAnnotation(scopedSymbol: FirRegularClassSymbol): Boolean {
-    return hasAnnotation(scopedSymbol, ClassIds.CONTRIBUTES_BINDING, session)
-  }
-
-  private fun isGeneratedProvidesCompanion(classSymbol: FirClassSymbol<*>): Boolean {
+  private fun isGeneratedHolderCompanion(classSymbol: FirClassSymbol<*>): Boolean {
     val parentClassId = classSymbol.classId.outerClassId ?: return false
     return classSymbol.origin == ContributesMultibindingScopedGeneratorKey.origin &&
       classSymbol.classKind == ClassKind.OBJECT &&
       classSymbol.classId.shortClassName == SpecialNames.DEFAULT_NAME_FOR_COMPANION_OBJECT &&
-      parentClassId.shortClassName == ContributesMultibindingScopedIds.NESTED_INTERFACE_NAME
+      parentClassId in generatedHolderClassIds
   }
 
-  private fun needsGeneratedProvidesCompanion(classSymbol: FirClassSymbol<*>): Boolean {
-    val scopedSymbol = scopedSymbolForGeneratedContribution(classSymbol) ?: return false
-    return needsProvidesFunction(scopedSymbol)
-  }
-
-  private fun scopedSymbolForGeneratedContribution(
-    classSymbol: FirClassSymbol<*>
-  ): FirRegularClassSymbol? {
-    if (
-      classSymbol.origin != ContributesMultibindingScopedGeneratorKey.origin ||
-        classSymbol.classId.shortClassName != ContributesMultibindingScopedIds.NESTED_INTERFACE_NAME
-    ) {
-      return null
-    }
-    val scopedClassId = classSymbol.classId.outerClassId ?: return null
-    return session.symbolProvider.getClassLikeSymbolByClassId(scopedClassId)
-      as? FirRegularClassSymbol
+  private fun hasLegacyScopedProviders(scopedSymbol: FirRegularClassSymbol): Boolean {
+    val legacyProviderClassId =
+      ContributesMultibindingScopedIds.legacyScopedProvidersClassId(scopedSymbol.classId)
+    return session.symbolProvider.getClassLikeSymbolByClassId(legacyProviderClassId) != null
   }
 
   private fun needsProvidesFunction(scopedSymbol: FirRegularClassSymbol): Boolean {
-    return !hasInjectAnnotation(scopedSymbol) && !hasContributesBindingAnnotation(scopedSymbol)
+    return !hasInjectAnnotation(scopedSymbol)
   }
 
-  private fun resolveParameterTypeRef(
-    parameter: FirValueParameter,
-    ownerSymbol: FirRegularClassSymbol,
-  ): FirTypeRef {
-    val returnTypeRef = parameter.returnTypeRef
-    if (returnTypeRef is FirResolvedTypeRef) return returnTypeRef
+  private fun buildScopeAnnotationCopies(
+    scopedSymbol: FirRegularClassSymbol,
+    containingSymbol: FirBasedSymbol<*>,
+  ): List<FirAnnotationCall> {
+    return scopedSymbol.resolvedCompilerAnnotationsWithClassIds.mapNotNull { annotation ->
+      val annotationCall = annotation as? FirAnnotationCall ?: return@mapNotNull null
+      if (!isScopeAnnotation(annotation)) return@mapNotNull null
+      NonAcceptingAnnotationCall(compatContext, annotationCall, containingSymbol)
+    }
+  }
 
-    val file = session.firProvider.getFirClassifierContainerFileIfAny(ownerSymbol)
-    val scopes =
-      if (file != null) {
-        createImportingScopes(file, session, ScopeSession())
-      } else {
-        emptyList()
-      }
+  private fun isScopeAnnotation(annotation: FirAnnotationCall): Boolean {
+    val annotationClassId = annotation.toAnnotationClassIdSafe(session) ?: return false
+    if (annotationClassId == ClassIds.SINGLE_IN) return true
 
-    return session.typeResolver
-      .resolveType(
-        typeRef = returnTypeRef,
-        configuration =
-          TypeResolutionConfiguration(
-            scopes = scopes,
-            containingClassDeclarations = emptyList(),
-            useSiteFile = file,
-          ),
-        areBareTypesAllowed = true,
-        isOperandOfIsOperator = false,
-        resolveDeprecations = false,
-        supertypeSupplier = SupertypeSupplier.Default,
-        expandTypeAliases = false,
-      )
-      .type
-      .toFirResolvedTypeRef()
+    val annotationClass =
+      session.symbolProvider.getClassLikeSymbolByClassId(annotationClassId)
+        as? FirRegularClassSymbol ?: return false
+    return annotationClass.resolvedCompilerAnnotationsWithClassIds.any { metaAnnotation ->
+      metaAnnotation.toAnnotationClassIdSafe(session) in ClassIds.SCOPE_CLASS_IDS
+    }
   }
 
   /**
@@ -525,6 +587,98 @@ public class ContributesMultibindingScopedFir(session: FirSession) :
       session: FirSession,
       options: MetroOptions,
       compatContext: CompatContext,
-    ): MetroFirDeclarationGenerationExtension = ContributesMultibindingScopedFir(session)
+    ): MetroFirDeclarationGenerationExtension =
+      ContributesMultibindingScopedFir(session, compatContext)
   }
+}
+
+private class NonAcceptingAnnotationCall(
+  private val compatContext: CompatContext,
+  private val delegate: FirAnnotationCall,
+  override val containingDeclarationSymbol: FirBasedSymbol<*>,
+) : FirAnnotationCall() {
+  override val source: KtSourceElement?
+    get() =
+      with(compatContext) { delegate.source?.fakeElement(KtFakeSourceElementKind.PluginGenerated) }
+
+  @UnresolvedExpressionTypeAccess
+  override val coneTypeOrNull: ConeKotlinType?
+    get() = delegate.coneTypeOrNull
+
+  override val annotations: List<FirAnnotation>
+    get() = delegate.annotations
+
+  override val useSiteTarget: AnnotationUseSiteTarget?
+    get() = delegate.useSiteTarget
+
+  override val annotationTypeRef: FirTypeRef
+    get() = delegate.annotationTypeRef
+
+  override val typeArguments: List<FirTypeProjection>
+    get() = delegate.typeArguments
+
+  override val argumentList: FirArgumentList
+    get() = delegate.argumentList
+
+  override val calleeReference: FirReference
+    get() = delegate.calleeReference
+
+  override val argumentMapping: FirAnnotationArgumentMapping
+    get() = delegate.argumentMapping
+
+  override val annotationResolvePhase: FirAnnotationResolvePhase
+    get() = delegate.annotationResolvePhase
+
+  override fun replaceConeTypeOrNull(newConeTypeOrNull: ConeKotlinType?) {
+    delegate.replaceConeTypeOrNull(newConeTypeOrNull)
+  }
+
+  override fun replaceAnnotations(newAnnotations: List<FirAnnotation>) {
+    delegate.replaceAnnotations(newAnnotations)
+  }
+
+  override fun replaceUseSiteTarget(newUseSiteTarget: AnnotationUseSiteTarget?) {
+    delegate.replaceUseSiteTarget(newUseSiteTarget)
+  }
+
+  override fun replaceAnnotationTypeRef(newAnnotationTypeRef: FirTypeRef) {
+    delegate.replaceAnnotationTypeRef(newAnnotationTypeRef)
+  }
+
+  override fun replaceTypeArguments(newTypeArguments: List<FirTypeProjection>) {
+    delegate.replaceTypeArguments(newTypeArguments)
+  }
+
+  override fun replaceArgumentList(newArgumentList: FirArgumentList) {
+    delegate.replaceArgumentList(newArgumentList)
+  }
+
+  override fun replaceCalleeReference(newCalleeReference: FirReference) {
+    delegate.replaceCalleeReference(newCalleeReference)
+  }
+
+  override fun replaceArgumentMapping(newArgumentMapping: FirAnnotationArgumentMapping) {
+    delegate.replaceArgumentMapping(newArgumentMapping)
+  }
+
+  override fun replaceAnnotationResolvePhase(newAnnotationResolvePhase: FirAnnotationResolvePhase) {
+    delegate.replaceAnnotationResolvePhase(newAnnotationResolvePhase)
+  }
+
+  override fun <D> transformAnnotations(transformer: FirTransformer<D>, data: D) =
+    delegate.transformAnnotations(transformer, data)
+
+  override fun <D> transformAnnotationTypeRef(transformer: FirTransformer<D>, data: D) =
+    delegate.transformAnnotationTypeRef(transformer, data)
+
+  override fun <D> transformTypeArguments(transformer: FirTransformer<D>, data: D) =
+    delegate.transformTypeArguments(transformer, data)
+
+  override fun <D> transformCalleeReference(transformer: FirTransformer<D>, data: D) =
+    delegate.transformCalleeReference(transformer, data)
+
+  override fun <R, D> acceptChildren(visitor: FirVisitor<R, D>, data: D) = Unit
+
+  override fun <D> transformChildren(transformer: FirTransformer<D>, data: D) =
+    delegate.transformChildren(transformer, data)
 }

--- a/compiler/src/main/kotlin/com/squareup/metro/extensions/scoped/ContributesMultibindingScopedIds.kt
+++ b/compiler/src/main/kotlin/com/squareup/metro/extensions/scoped/ContributesMultibindingScopedIds.kt
@@ -20,8 +20,40 @@ internal object ContributesMultibindingScopedIds {
   val CONTRIBUTES_MULTIBINDING_SCOPED_FQ_NAME =
     FqName("com.squareup.dagger.ContributesMultibindingScoped")
 
-  val NESTED_INTERFACE_NAME = Name.identifier("MultibindingScopedContribution")
+  val HOLDER_CLASS_SUFFIX = "MultibindingScopedContributions"
+  val CONTRIBUTION_CLASS_SUFFIX = "MultibindingScopedContribution"
+
+  val NESTED_INTERFACE_NAME = Name.identifier(CONTRIBUTION_CLASS_SUFFIX)
 
   /** Predicate matching classes annotated with `@ContributesMultibindingScoped`. */
   val PREDICATE = LookupPredicate.create { annotated(CONTRIBUTES_MULTIBINDING_SCOPED_FQ_NAME) }
+
+  fun holderClassId(contributedClassId: ClassId): ClassId {
+    val contributedName =
+      contributedClassId.relativeClassName.pathSegments().joinToString(separator = "") {
+        it.asString()
+      }
+    return ClassId(
+      contributedClassId.packageFqName,
+      Name.identifier("$contributedName$HOLDER_CLASS_SUFFIX"),
+    )
+  }
+
+  fun contributionClassId(contributedClassId: ClassId): ClassId {
+    return holderClassId(contributedClassId).createNestedClassId(NESTED_INTERFACE_NAME)
+  }
+
+  fun legacyScopedProvidersClassId(contributedClassId: ClassId): ClassId {
+    val contributedPackage = contributedClassId.packageFqName.asString()
+    val packageName =
+      if (contributedPackage.isEmpty()) {
+        "anvil.register.scoped"
+      } else {
+        "anvil.register.scoped.$contributedPackage"
+      }
+    return ClassId(
+      FqName(packageName),
+      Name.identifier("${contributedClassId.shortClassName.asString()}ScopedProviders"),
+    )
+  }
 }

--- a/compiler/src/main/kotlin/com/squareup/metro/extensions/scoped/ContributesMultibindingScopedIrExtension.kt
+++ b/compiler/src/main/kotlin/com/squareup/metro/extensions/scoped/ContributesMultibindingScopedIrExtension.kt
@@ -1,19 +1,28 @@
 package com.squareup.metro.extensions.scoped
 
+import com.squareup.metro.extensions.ClassIds
 import com.squareup.metro.extensions.Keys.ContributesMultibindingScopedGeneratorKey
 import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
 import org.jetbrains.kotlin.ir.IrStatement
+import org.jetbrains.kotlin.ir.UNDEFINED_OFFSET
 import org.jetbrains.kotlin.ir.builders.irBlockBody
 import org.jetbrains.kotlin.ir.builders.irCall
 import org.jetbrains.kotlin.ir.builders.irGet
 import org.jetbrains.kotlin.ir.builders.irReturn
 import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrConstructor
+import org.jetbrains.kotlin.ir.declarations.IrDeclaration
 import org.jetbrains.kotlin.ir.declarations.IrDeclarationOrigin
 import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
 import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
+import org.jetbrains.kotlin.ir.expressions.IrClassReference
+import org.jetbrains.kotlin.ir.expressions.IrDelegatingConstructorCall
+import org.jetbrains.kotlin.ir.expressions.IrExpression
+import org.jetbrains.kotlin.ir.types.classOrNull
+import org.jetbrains.kotlin.ir.util.classId
+import org.jetbrains.kotlin.ir.util.parentAsClass
 import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
 import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
 
@@ -34,38 +43,62 @@ private class ContributesMultibindingScopedIrTransformer(
   private val pluginContext: IrPluginContext
 ) : IrElementTransformerVoid() {
 
+  override fun visitConstructor(declaration: IrConstructor): IrStatement {
+    val origin = declaration.origin
+    if (origin is IrDeclarationOrigin.GeneratedByPlugin) {
+      declaration.startOffset = UNDEFINED_OFFSET
+      declaration.endOffset = UNDEFINED_OFFSET
+      declaration.body?.transformChildrenVoid(GeneratedConstructorOffsetTransformer)
+    }
+    return super.visitConstructor(declaration)
+  }
+
+  override fun visitDelegatingConstructorCall(
+    expression: IrDelegatingConstructorCall
+  ): IrExpression {
+    return super.visitDelegatingConstructorCall(expression)
+  }
+
   override fun visitSimpleFunction(declaration: IrSimpleFunction): IrStatement {
     val origin = declaration.origin
+    val generatedByPlugin = origin is IrDeclarationOrigin.GeneratedByPlugin
     if (
-      origin !is IrDeclarationOrigin.GeneratedByPlugin ||
-        origin.pluginKey != ContributesMultibindingScopedGeneratorKey
+      generatedByPlugin &&
+        origin.pluginKey == ContributesMultibindingScopedGeneratorKey &&
+        declaration.body == null &&
+        declaration.name.asString().startsWith(SCOPED_PROVIDER_FUNCTION_PREFIX)
     ) {
-      return super.visitSimpleFunction(declaration)
-    }
-    if (declaration.body != null) return super.visitSimpleFunction(declaration)
-    if (declaration.name.asString() != SCOPED_PROVIDER_FUNCTION_NAME) {
-      return super.visitSimpleFunction(declaration)
+      generateProvidesBody(declaration)
     }
 
-    generateProvidesBody(declaration)
+    val result = super.visitSimpleFunction(declaration)
+    if (generatedByPlugin || hasGeneratedParent(declaration)) {
+      declaration.startOffset = UNDEFINED_OFFSET
+      declaration.endOffset = UNDEFINED_OFFSET
+      declaration.body?.transformChildrenVoid(GeneratedBodyOffsetTransformer)
+    }
+    return result
+  }
 
-    return super.visitSimpleFunction(declaration)
+  private fun hasGeneratedParent(declaration: IrDeclaration): Boolean {
+    var parent = declaration.parent
+    while (parent is IrDeclaration) {
+      if (parent.origin is IrDeclarationOrigin.GeneratedByPlugin) return true
+      parent = parent.parent
+    }
+    return false
   }
 
   private fun generateProvidesBody(declaration: IrSimpleFunction) {
-    val companionObject = declaration.parent as? IrClass ?: return
-    val contributionInterface = companionObject.parent as? IrClass ?: return
-    val scopedClass = contributionInterface.parent as? IrClass ?: return
+    val scopedClass =
+      declaration.returnType.classOrNull?.owner?.takeIf { clazz ->
+        clazz.declarations.any { it is IrConstructor }
+      } ?: originClass(declaration) ?: return
     val constructor =
       scopedClass.declarations.filterIsInstance<IrConstructor>().firstOrNull() ?: return
 
     val irBuilder =
-      DeclarationIrBuilder(
-        pluginContext,
-        declaration.symbol,
-        declaration.startOffset,
-        declaration.endOffset,
-      )
+      DeclarationIrBuilder(pluginContext, declaration.symbol, UNDEFINED_OFFSET, UNDEFINED_OFFSET)
 
     val constructorParameters = constructor.parameters
     val providerParameters = constructorParameters.map { constructorParameter ->
@@ -80,9 +113,53 @@ private class ContributesMultibindingScopedIrTransformer(
       }
 
     declaration.body = irBuilder.irBlockBody { +irReturn(constructorCall) }
+    declaration.startOffset = UNDEFINED_OFFSET
+    declaration.endOffset = UNDEFINED_OFFSET
+    declaration.body?.transformChildrenVoid(GeneratedBodyOffsetTransformer)
+  }
+
+  private fun originClass(declaration: IrDeclaration): IrClass? {
+    var parent = declaration.parent
+    while (parent is IrClass) {
+      val originAnnotation =
+        parent.annotations.firstOrNull { annotation ->
+          annotation.symbol.owner.parentAsClass.classId == ClassIds.ORIGIN
+        }
+      val originClass =
+        originAnnotation
+          ?.arguments
+          ?.firstOrNull()
+          ?.let { it as? IrClassReference }
+          ?.classType
+          ?.classOrNull
+          ?.owner
+      if (originClass != null) return originClass
+      parent = parent.parent
+    }
+    return null
   }
 
   private companion object {
-    const val SCOPED_PROVIDER_FUNCTION_NAME = "provideContributedMultibindingScoped"
+    const val SCOPED_PROVIDER_FUNCTION_PREFIX = "provide"
+
+    val GeneratedConstructorOffsetTransformer =
+      object : IrElementTransformerVoid() {
+        override fun visitDelegatingConstructorCall(
+          expression: IrDelegatingConstructorCall
+        ): IrExpression {
+          expression.startOffset = UNDEFINED_OFFSET
+          expression.endOffset = UNDEFINED_OFFSET
+          return super.visitDelegatingConstructorCall(expression)
+        }
+      }
+
+    val GeneratedBodyOffsetTransformer =
+      object : IrElementTransformerVoid() {
+        override fun visitExpression(expression: IrExpression): IrExpression {
+          expression.startOffset = UNDEFINED_OFFSET
+          expression.endOffset = UNDEFINED_OFFSET
+          return super.visitExpression(expression)
+        }
+      }
   }
 }

--- a/compiler/src/main/kotlin/com/squareup/metro/extensions/scoped/ContributesMultibindingScopedMetroExtension.kt
+++ b/compiler/src/main/kotlin/com/squareup/metro/extensions/scoped/ContributesMultibindingScopedMetroExtension.kt
@@ -11,8 +11,6 @@ import org.jetbrains.kotlin.fir.extensions.FirDeclarationPredicateRegistrar
 import org.jetbrains.kotlin.fir.extensions.predicateBasedProvider
 import org.jetbrains.kotlin.fir.resolve.defaultType
 import org.jetbrains.kotlin.fir.resolve.providers.symbolProvider
-import org.jetbrains.kotlin.fir.scopes.getSingleClassifier
-import org.jetbrains.kotlin.fir.scopes.impl.declaredMemberScope
 import org.jetbrains.kotlin.fir.symbols.impl.FirRegularClassSymbol
 import org.jetbrains.kotlin.name.ClassId
 
@@ -46,40 +44,46 @@ public class ContributesMultibindingScopedMetroExtension(private val session: Fi
     scopeClassId: ClassId,
     typeResolverFactory: MetroFirTypeResolver.Factory,
   ): List<MetroContributionExtension.Contribution> {
-    return annotatedClasses.mapNotNull { parentSymbol ->
+    return annotatedClasses.flatMap { parentSymbol ->
       val annotationScopeClassId =
         extractScopeClassId(
           parentSymbol,
           ContributesMultibindingScopedIds.CONTRIBUTES_MULTIBINDING_SCOPED_CLASS_ID,
           session,
-        ) ?: return@mapNotNull null
+        ) ?: return@flatMap emptyList()
 
-      if (annotationScopeClassId != scopeClassId) return@mapNotNull null
+      if (annotationScopeClassId != scopeClassId) return@flatMap emptyList()
 
       val contributionInterfaceClassId =
-        parentSymbol.classId.createNestedClassId(
-          ContributesMultibindingScopedIds.NESTED_INTERFACE_NAME
-        )
+        ContributesMultibindingScopedIds.contributionClassId(parentSymbol.classId)
+      val holderClassId = ContributesMultibindingScopedIds.holderClassId(parentSymbol.classId)
 
       val contributionSymbol =
         session.symbolProvider.getClassLikeSymbolByClassId(contributionInterfaceClassId)
-          as? FirRegularClassSymbol ?: return@mapNotNull null
+          as? FirRegularClassSymbol
+      val holderSymbol =
+        session.symbolProvider.getClassLikeSymbolByClassId(holderClassId) as? FirRegularClassSymbol
 
-      // Trigger Metro's FIR generator to create the MetroContribution nested class.
-      val scope = contributionSymbol.declaredMemberScope(session, memberRequiredPhase = null)
-      val metroContributionName =
-        scope.getClassifierNames().firstOrNull { it.identifier.startsWith("MetroContributionTo") }
-          ?: return@mapNotNull null
-
-      val metroContributionSymbol =
-        scope.getSingleClassifier(metroContributionName) as? FirRegularClassSymbol
-          ?: return@mapNotNull null
-
-      MetroContributionExtension.Contribution(
-        supertype = metroContributionSymbol.defaultType(),
-        replaces = emptyList(),
-        originClassId = contributionInterfaceClassId,
-      )
+      buildList {
+        if (holderSymbol != null) {
+          add(
+            MetroContributionExtension.Contribution(
+              supertype = holderSymbol.defaultType(),
+              replaces = emptyList(),
+              originClassId = holderClassId,
+            )
+          )
+        }
+        if (contributionSymbol != null) {
+          add(
+            MetroContributionExtension.Contribution(
+              supertype = contributionSymbol.defaultType(),
+              replaces = emptyList(),
+              originClassId = contributionInterfaceClassId,
+            )
+          )
+        }
+      }
     }
   }
 

--- a/compiler/src/main/kotlin/com/squareup/metro/extensions/service/ContributesServiceFir.kt
+++ b/compiler/src/main/kotlin/com/squareup/metro/extensions/service/ContributesServiceFir.kt
@@ -11,6 +11,7 @@ import com.squareup.metro.extensions.fir.extractScopeArgument
 import com.squareup.metro.extensions.fir.extractScopeClassId
 import com.squareup.metro.extensions.fir.findAnnotation
 import com.squareup.metro.extensions.fir.hasAnnotation
+import com.squareup.metro.extensions.fir.resolveValueParameterTypeRef
 import com.squareup.metro.extensions.squareMetroExtensionsConfig
 import dev.zacsweers.metro.compiler.MetroOptions
 import dev.zacsweers.metro.compiler.api.fir.MetroFirDeclarationGenerationExtension
@@ -22,7 +23,6 @@ import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.declarations.DirectDeclarationsAccess
 import org.jetbrains.kotlin.fir.declarations.FirFunction
 import org.jetbrains.kotlin.fir.declarations.FirResolvePhase
-import org.jetbrains.kotlin.fir.declarations.FirValueParameter
 import org.jetbrains.kotlin.fir.declarations.builder.buildNamedFunction
 import org.jetbrains.kotlin.fir.declarations.builder.buildRegularClass
 import org.jetbrains.kotlin.fir.declarations.builder.buildValueParameter
@@ -48,14 +48,8 @@ import org.jetbrains.kotlin.fir.extensions.predicateBasedProvider
 import org.jetbrains.kotlin.fir.moduleData
 import org.jetbrains.kotlin.fir.plugin.createDefaultPrivateConstructor
 import org.jetbrains.kotlin.fir.references.builder.buildResolvedNamedReference
-import org.jetbrains.kotlin.fir.resolve.ScopeSession
-import org.jetbrains.kotlin.fir.resolve.SupertypeSupplier
-import org.jetbrains.kotlin.fir.resolve.TypeResolutionConfiguration
 import org.jetbrains.kotlin.fir.resolve.defaultType
-import org.jetbrains.kotlin.fir.resolve.providers.firProvider
 import org.jetbrains.kotlin.fir.resolve.providers.symbolProvider
-import org.jetbrains.kotlin.fir.resolve.typeResolver
-import org.jetbrains.kotlin.fir.scopes.createImportingScopes
 import org.jetbrains.kotlin.fir.scopes.kotlinScopeProvider
 import org.jetbrains.kotlin.fir.symbols.FirBasedSymbol
 import org.jetbrains.kotlin.fir.symbols.SymbolInternals
@@ -69,8 +63,6 @@ import org.jetbrains.kotlin.fir.symbols.impl.FirValueParameterSymbol
 import org.jetbrains.kotlin.fir.toEffectiveVisibility
 import org.jetbrains.kotlin.fir.toFirResolvedTypeRef
 import org.jetbrains.kotlin.fir.types.ConeKotlinType
-import org.jetbrains.kotlin.fir.types.FirResolvedTypeRef
-import org.jetbrains.kotlin.fir.types.FirTypeRef
 import org.jetbrains.kotlin.fir.types.impl.ConeClassLikeTypeImpl
 import org.jetbrains.kotlin.name.CallableId
 import org.jetbrains.kotlin.name.ClassId
@@ -596,7 +588,7 @@ public class ContributesServiceFir(session: FirSession) :
           resolvePhase = FirResolvePhase.BODY_RESOLVE
           moduleData = session.moduleData
           origin = ContributesServiceGeneratorKey.origin
-          returnTypeRef = resolveParameterTypeRef(parameter, fakeOwner)
+          returnTypeRef = resolveValueParameterTypeRef(parameter, fakeOwner, session)
           this.name = parameter.name
           symbol = FirValueParameterSymbol()
           containingDeclarationSymbol = functionSymbol
@@ -737,40 +729,6 @@ public class ContributesServiceFir(session: FirSession) :
           annotation.toAnnotationClassIdSafe(session) == ClassIds.INJECT
         }
       }
-  }
-
-  private fun resolveParameterTypeRef(
-    parameter: FirValueParameter,
-    ownerSymbol: FirRegularClassSymbol,
-  ): FirTypeRef {
-    val returnTypeRef = parameter.returnTypeRef
-    if (returnTypeRef is FirResolvedTypeRef) return returnTypeRef
-
-    val file = session.firProvider.getFirClassifierContainerFileIfAny(ownerSymbol)
-    val scopes =
-      if (file != null) {
-        createImportingScopes(file, session, ScopeSession())
-      } else {
-        emptyList()
-      }
-
-    return session.typeResolver
-      .resolveType(
-        typeRef = returnTypeRef,
-        configuration =
-          TypeResolutionConfiguration(
-            scopes = scopes,
-            containingClassDeclarations = emptyList(),
-            useSiteFile = file,
-          ),
-        areBareTypesAllowed = true,
-        isOperandOfIsOperator = false,
-        resolveDeprecations = false,
-        supertypeSupplier = SupertypeSupplier.Default,
-        expandTypeAliases = false,
-      )
-      .type
-      .toFirResolvedTypeRef()
   }
 
   private fun buildSimpleAnnotation(classId: ClassId): FirAnnotation {

--- a/compiler/src/test/java/com/squareup/metro/extensions/runners/BoxTestGenerated.java
+++ b/compiler/src/test/java/com/squareup/metro/extensions/runners/BoxTestGenerated.java
@@ -77,6 +77,12 @@ public class BoxTestGenerated extends AbstractBoxTest {
     }
 
     @Test
+    @TestMetadata("contributesBindingScopedMultiCompilation.kt")
+    public void testContributesBindingScopedMultiCompilation() {
+      runTest("compiler/src/test/resources/box/contributesmultibindingscoped/contributesBindingScopedMultiCompilation.kt");
+    }
+
+    @Test
     @TestMetadata("excludedScopedBinding.kt")
     public void testExcludedScopedBinding() {
       runTest("compiler/src/test/resources/box/contributesmultibindingscoped/excludedScopedBinding.kt");

--- a/compiler/src/test/resources/box/contributesmultibindingscoped/constructorProvider.kt
+++ b/compiler/src/test/resources/box/contributesmultibindingscoped/constructorProvider.kt
@@ -20,17 +20,18 @@ interface MyGraph {
 }
 
 fun box(): String {
+  val holderClass = Class.forName("com.test.MyScopedMultibindingScopedContributions")
   val contributionClass =
-    MyScoped::class.java.declaredClasses.first {
-      it.simpleName == "MultibindingScopedContribution"
-    }
+    Class.forName(
+      "com.test.MyScopedMultibindingScopedContributions\$MultibindingScopedContribution"
+    )
   assertNotNull(contributionClass.getAnnotation(BindingContainer::class.java))
   val providerMethod =
     contributionClass.declaredMethods.firstOrNull {
       it.name == "provideContributedMultibindingScoped"
     }
   assertNull(providerMethod)
-  val companionClass = contributionClass.declaredClasses.first { it.simpleName == "Companion" }
+  val companionClass = holderClass.declaredClasses.first { it.simpleName == "Companion" }
   val companionProviderMethod =
     companionClass.declaredMethods.firstOrNull {
       it.name == "provideContributedMultibindingScoped"

--- a/compiler/src/test/resources/box/contributesmultibindingscoped/contributesBindingOnSameClass.kt
+++ b/compiler/src/test/resources/box/contributesmultibindingscoped/contributesBindingOnSameClass.kt
@@ -3,6 +3,7 @@ package com.test
 import com.squareup.dagger.ContributesMultibindingScoped
 import dev.zacsweers.metro.BindingContainer
 import dev.zacsweers.metro.ForScope
+import dev.zacsweers.metro.SingleIn
 import mortar.Scoped
 
 interface MyService {
@@ -13,6 +14,7 @@ class Dependency(val value: String)
 
 @ContributesBinding(Unit::class, binding = binding<MyService>())
 @ContributesMultibindingScoped(Unit::class)
+@SingleIn(Unit::class)
 class MyScopedService(dependency: Dependency) : MyService, Scoped {
   override val value: String = dependency.value
 }
@@ -27,16 +29,25 @@ interface MyGraph {
 }
 
 fun box(): String {
+  val holderClass =
+    Class.forName("com.test.MyScopedServiceMultibindingScopedContributions")
   val contributionClass =
-    MyScopedService::class.java.declaredClasses.first {
-      it.simpleName == "MultibindingScopedContribution"
-    }
+    Class.forName(
+      "com.test.MyScopedServiceMultibindingScopedContributions\$MultibindingScopedContribution"
+    )
   assertNotNull(contributionClass.getAnnotation(BindingContainer::class.java))
   val providerMethod =
-    (listOf(contributionClass) + contributionClass.declaredClasses.toList())
-      .flatMap { it.declaredMethods.toList() }
-      .firstOrNull { it.name == "provideContributedMultibindingScoped" }
+    contributionClass.declaredMethods.firstOrNull {
+      it.name == "provideContributedMultibindingScoped"
+    }
   assertNull(providerMethod)
+  val companionClass = holderClass.declaredClasses.first { it.simpleName == "Companion" }
+  val companionProviderMethod =
+    companionClass.declaredMethods.firstOrNull {
+      it.name == "provideContributedMultibindingScoped"
+    }
+  assertNotNull(companionProviderMethod)
+  assertNotNull(companionProviderMethod?.getAnnotation(SingleIn::class.java))
 
   val graph = createGraph<MyGraph>()
   assertTrue(graph.myService is MyScopedService)

--- a/compiler/src/test/resources/box/contributesmultibindingscoped/contributesBindingScopedMultiCompilation.kt
+++ b/compiler/src/test/resources/box/contributesmultibindingscoped/contributesBindingScopedMultiCompilation.kt
@@ -1,0 +1,35 @@
+// MODULE: lib
+package com.test
+
+import com.squareup.dagger.ContributesMultibindingScoped
+import dev.zacsweers.metro.SingleIn
+import mortar.Scoped
+
+class Dependency @Inject constructor()
+
+interface MyService
+
+@SingleIn(Unit::class)
+@ContributesBinding(Unit::class, binding = binding<MyService>())
+@ContributesMultibindingScoped(Unit::class)
+class RealService(val dependency: Dependency) : MyService, Scoped
+
+// MODULE: main(lib)
+import com.test.RealService
+import com.test.MyService
+import dev.zacsweers.metro.ForScope
+import mortar.Scoped
+
+@DependencyGraph(Unit::class)
+interface MyGraph {
+  val myService: MyService
+
+  @ForScope(Unit::class) val scoped: Set<Scoped>
+}
+
+fun box(): String {
+  val graph = createGraph<MyGraph>()
+  assertTrue(graph.myService is RealService)
+  assertTrue(graph.scoped.single() is RealService)
+  return "OK"
+}

--- a/compiler/src/test/resources/box/contributesmultibindingscoped/hintGeneratedFir.kt
+++ b/compiler/src/test/resources/box/contributesmultibindingscoped/hintGeneratedFir.kt
@@ -17,9 +17,11 @@ fun box(): String {
   // Verify that the scope hint function was generated for the @ContributesTo interface.
   // Metro uses these hints to discover cross-module contributions.
   val hintClass = try {
-    Class.forName("metro.hints.ComTestMyTestClassMultibindingScopedContributionUnitKt")
+    Class.forName(
+      "metro.hints.ComTestMyTestClassMultibindingScopedContributionsMultibindingScopedContributionUnitKt"
+    )
   } catch (e: ClassNotFoundException) {
-    return "FAIL: Scope hint not generated for MyTestClass.MultibindingScopedContribution"
+    return "FAIL: Scope hint not generated for MyTestClassMultibindingScopedContributions.MultibindingScopedContribution"
   }
 
   val hintFunction = hintClass.methods.find { it.name == "Unit" }

--- a/compiler/src/test/resources/box/contributesmultibindingscoped/hintGeneratedIr.kt
+++ b/compiler/src/test/resources/box/contributesmultibindingscoped/hintGeneratedIr.kt
@@ -15,9 +15,11 @@ fun box(): String {
   // Verify that the scope hint function was generated for the @ContributesTo interface.
   // Metro uses these hints to discover cross-module contributions.
   val hintClass = try {
-    Class.forName("metro.hints.ComTestMyTestClassMultibindingScopedContributionUnitKt")
+    Class.forName(
+      "metro.hints.ComTestMyTestClassMultibindingScopedContributionsMultibindingScopedContributionUnitKt"
+    )
   } catch (e: ClassNotFoundException) {
-    return "FAIL: Scope hint not generated for MyTestClass.MultibindingScopedContribution"
+    return "FAIL: Scope hint not generated for MyTestClassMultibindingScopedContributions.MultibindingScopedContribution"
   }
 
   val hintFunction = hintClass.methods.find { it.name == "Unit" }

--- a/compiler/src/test/resources/box/contributesmultibindingscoped/secondaryInjectConstructorSkipsProvider.kt
+++ b/compiler/src/test/resources/box/contributesmultibindingscoped/secondaryInjectConstructorSkipsProvider.kt
@@ -23,9 +23,9 @@ interface MyGraph {
 
 fun box(): String {
   val contributionClass =
-    MyScoped::class.java.declaredClasses.first {
-      it.simpleName == "MultibindingScopedContribution"
-    }
+    Class.forName(
+      "com.test.MyScopedMultibindingScopedContributions\$MultibindingScopedContribution"
+    )
   assertNotNull(contributionClass.getAnnotation(BindingContainer::class.java))
   val providerMethod =
     (listOf(contributionClass) + contributionClass.declaredClasses.toList())

--- a/compiler/src/test/resources/dump/contributesmultibindingscoped/contributesMultibindingScoped.fir.txt
+++ b/compiler/src/test/resources/dump/contributesmultibindingscoped/contributesMultibindingScoped.fir.txt
@@ -6,25 +6,30 @@ FILE: contributesMultibindingScoped.kt
             super<R|kotlin/Any|>()
         }
 
-        @R|dev/zacsweers/metro/ContributesTo|(scope = <getClass>(Q|kotlin/Unit|)) @R|dev/zacsweers/metro/BindingContainer|() @R|dev/zacsweers/metro/Origin|(value = <getClass>(Q|com/test/MyTestClass|)) public abstract interface MultibindingScopedContribution : R|kotlin/Any| {
-            @R|dev/zacsweers/metro/Binds|() @R|dev/zacsweers/metro/IntoSet|() @R|dev/zacsweers/metro/ForScope|(scope = <getClass>(Q|kotlin/Unit|)) public abstract fun bindsMyTestClass(myTestClass: R|com/test/MyTestClass|): R|mortar/Scoped|
-
-            @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) public abstract class BindsMirror : R|kotlin/Any| {
-                private constructor(): R|com/test/MyTestClass.MultibindingScopedContribution.BindsMirror| {
-                    super<R|kotlin/Any|>()
-                }
-
-                private constructor(): R|com/test/MyTestClass.MultibindingScopedContribution.BindsMirror| {
-                    super<R|kotlin/Any|>()
-                }
-
+        @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) public final object MetroFactory : R|kotlin/Any| {
+            private constructor(): R|com/test/MyTestClass.MetroFactory| {
+                super<R|kotlin/Any|>()
             }
 
         }
 
-        @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) public final object MetroFactory : R|kotlin/Any| {
-            private constructor(): R|com/test/MyTestClass.MetroFactory| {
-                super<R|kotlin/Any|>()
+    }
+FILE: com/test/MyTestClassMultibindingScopedContributions.kt
+    package com.test
+
+    @R|dev/zacsweers/metro/ContributesTo|(scope = <getClass>(Q|kotlin/Unit|)) @R|dev/zacsweers/metro/BindingContainer|() @R|dev/zacsweers/metro/Origin|(value = <getClass>(Q|com/test/MyTestClass|)) public abstract interface MyTestClassMultibindingScopedContributions : R|kotlin/Any| {
+        @R|dev/zacsweers/metro/ContributesTo|(scope = <getClass>(Q|kotlin/Unit|)) @R|dev/zacsweers/metro/BindingContainer|() @R|dev/zacsweers/metro/Origin|(value = <getClass>(Q|com/test/MyTestClass|)) public abstract interface MultibindingScopedContribution : R|kotlin/Any| {
+            @R|dev/zacsweers/metro/Binds|() @R|dev/zacsweers/metro/IntoSet|() @R|dev/zacsweers/metro/ForScope|(scope = <getClass>(Q|kotlin/Unit|)) public abstract fun bindsMyTestClass(myTestClass: R|com/test/MyTestClass|): R|mortar/Scoped|
+
+            @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) public abstract class BindsMirror : R|kotlin/Any| {
+                private constructor(): R|com/test/MyTestClassMultibindingScopedContributions.MultibindingScopedContribution.BindsMirror| {
+                    super<R|kotlin/Any|>()
+                }
+
+                private constructor(): R|com/test/MyTestClassMultibindingScopedContributions.MultibindingScopedContribution.BindsMirror| {
+                    super<R|kotlin/Any|>()
+                }
+
             }
 
         }

--- a/compiler/src/test/resources/dump/contributesmultibindingscoped/scopedInSuperTypes.fir.txt
+++ b/compiler/src/test/resources/dump/contributesmultibindingscoped/scopedInSuperTypes.fir.txt
@@ -8,25 +8,30 @@ FILE: scopedInSuperTypes.kt
             super<R|kotlin/Any|>()
         }
 
-        @R|dev/zacsweers/metro/ContributesTo|(scope = <getClass>(Q|kotlin/Unit|)) @R|dev/zacsweers/metro/BindingContainer|() @R|dev/zacsweers/metro/Origin|(value = <getClass>(Q|com/test/Service|)) public abstract interface MultibindingScopedContribution : R|kotlin/Any| {
-            @R|dev/zacsweers/metro/Binds|() @R|dev/zacsweers/metro/IntoSet|() @R|dev/zacsweers/metro/ForScope|(scope = <getClass>(Q|kotlin/Unit|)) public abstract fun bindsService(service: R|com/test/Service|): R|mortar/Scoped|
-
-            @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) public abstract class BindsMirror : R|kotlin/Any| {
-                private constructor(): R|com/test/Service.MultibindingScopedContribution.BindsMirror| {
-                    super<R|kotlin/Any|>()
-                }
-
-                private constructor(): R|com/test/Service.MultibindingScopedContribution.BindsMirror| {
-                    super<R|kotlin/Any|>()
-                }
-
+        @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) public final object MetroFactory : R|kotlin/Any| {
+            private constructor(): R|com/test/Service.MetroFactory| {
+                super<R|kotlin/Any|>()
             }
 
         }
 
-        @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) public final object MetroFactory : R|kotlin/Any| {
-            private constructor(): R|com/test/Service.MetroFactory| {
-                super<R|kotlin/Any|>()
+    }
+FILE: com/test/ServiceMultibindingScopedContributions.kt
+    package com.test
+
+    @R|dev/zacsweers/metro/ContributesTo|(scope = <getClass>(Q|kotlin/Unit|)) @R|dev/zacsweers/metro/BindingContainer|() @R|dev/zacsweers/metro/Origin|(value = <getClass>(Q|com/test/Service|)) public abstract interface ServiceMultibindingScopedContributions : R|kotlin/Any| {
+        @R|dev/zacsweers/metro/ContributesTo|(scope = <getClass>(Q|kotlin/Unit|)) @R|dev/zacsweers/metro/BindingContainer|() @R|dev/zacsweers/metro/Origin|(value = <getClass>(Q|com/test/Service|)) public abstract interface MultibindingScopedContribution : R|kotlin/Any| {
+            @R|dev/zacsweers/metro/Binds|() @R|dev/zacsweers/metro/IntoSet|() @R|dev/zacsweers/metro/ForScope|(scope = <getClass>(Q|kotlin/Unit|)) public abstract fun bindsService(service: R|com/test/Service|): R|mortar/Scoped|
+
+            @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) public abstract class BindsMirror : R|kotlin/Any| {
+                private constructor(): R|com/test/ServiceMultibindingScopedContributions.MultibindingScopedContribution.BindsMirror| {
+                    super<R|kotlin/Any|>()
+                }
+
+                private constructor(): R|com/test/ServiceMultibindingScopedContributions.MultibindingScopedContribution.BindsMirror| {
+                    super<R|kotlin/Any|>()
+                }
+
             }
 
         }

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -292,8 +292,8 @@ real and fake must use the same scope.
 
 Contributes a class implementing `Scoped` into a `Set<Scoped>` qualified with `@ForScope`. The
 scope value is used for both the contribution target and the `@ForScope` qualifier, since they are
-always the same. If the class is not already injectable with `@Inject` or `@ContributesBinding`, the
-plugin also generates a `@Provides` function that calls the constructor.
+always the same. If the class is not already injectable with `@Inject`, the plugin also generates a
+`@Provides` function that calls the constructor.
 
 ### Annotation definition
 
@@ -339,9 +339,8 @@ interface MultibindingScopedContribution {
 
 Note: the scope from the annotation (`AppScope`) is used in two places -- as the
 `@ContributesTo` scope and as the `@ForScope` qualifier value. If the class or selected constructor
-is annotated with `@Inject`, or the class also has `@ContributesBinding`, the constructor provider is
-not generated. Classes with multiple constructors must mark the class or selected constructor with
-`@Inject`.
+is annotated with `@Inject`, the constructor provider is not generated. Classes with multiple
+constructors must mark the class or selected constructor with `@Inject`.
 
 ---
 


### PR DESCRIPTION
Generate `@ContributesMultibindingScoped` holders with stable generated identities while retaining `@Origin` metadata for the original scoped class. This keeps Metro replacement and exclusion matching on the source class without colliding with native `@ContributesBinding` contributions.

Also share constructor parameter type resolution across generated `@Provides` methods for `@ContributesRobot`, `@ContributesService`, and `@ContributesMultibindingScoped` so provider signatures keep imported and generic parameter types intact.