### PR TITLE
Release 0.0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@
 
 ### Added
 
-- Support for Kotlin `2.4.0`.
-
 ### Changed
 
 ### Deprecated
@@ -18,6 +16,12 @@
 
 ### Other Notes & Contributions
 
+
+## [0.0.12] - 2026-06-11
+
+### Added
+
+- Support for Kotlin `2.4.0`.
 
 ## [0.0.11] - 2026-05-14
 
@@ -114,7 +118,8 @@
 - Support for `@ContributesRobot`.
 
 
-[Unreleased]: https://github.com/square/metro-extensions/compare/0.0.11...HEAD
+[Unreleased]: https://github.com/square/metro-extensions/compare/0.0.12...HEAD
+[0.0.12]: https://github.com/square/metro-extensions/compare/0.0.12
 [0.0.11]: https://github.com/square/metro-extensions/compare/0.0.11
 [0.0.10]: https://github.com/square/metro-extensions/compare/0.0.10
 [0.0.9]: https://github.com/square/metro-extensions/compare/0.0.9

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=0.0.12-SNAPSHOT
+VERSION_NAME=0.0.12
 GROUP=com.squareup.metro.extensions
 
 org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=0.0.12
+VERSION_NAME=0.0.13-SNAPSHOT
 GROUP=com.squareup.metro.extensions
 
 org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8


### PR DESCRIPTION
Cuts the **0.0.12** release.

### Changes in this release
- Support for Kotlin `2.4.0`.

### Commits
- `Releasing 0.0.12.` — sets `VERSION_NAME=0.0.12`, finalizes the `[0.0.12]` CHANGELOG section, updates comparison links.
- `Prepare next development version.` — bumps `VERSION_NAME` to `0.0.13-SNAPSHOT`.

### Release mechanics
Generated by `./release.sh`. After this PR rebase-merges into `main`, the `0.0.12` tag will be re-created on the merged "Releasing 0.0.12." commit and pushed, which triggers the Maven Central publish + GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)