### PR TITLE
Bump action-gh-release to v3 for Node 24 [CLF-94]

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -57,7 +57,7 @@ jobs:
           fi
 
       - name: Create release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           body: ${{ steps.release_notes.outputs.release_notes }}
           prerelease: ${{ steps.prerelease.outputs.isPrerelease }}


### PR DESCRIPTION
## What

Bumps `softprops/action-gh-release@v2` → `@v3` in `.github/workflows/publish-release.yml`.

## Why

`action-gh-release@v2` runs on Node.js 20. GitHub flagged a deprecation during the `0.0.12` release run:

- **2026-06-16** — Node 20 actions are forced to Node 24 by default.
- **2026-09-16** — Node 20 is removed from runners entirely.

Per the action's [v3.0.0 release notes](https://github.com/softprops/action-gh-release/releases/tag/v3.0.0), `v3` is a major release that moves the runtime from Node 20 to Node 24, keeps the floating `v3` major tag, and notes `v2.6.2` was the last Node 20 line. This keeps the release job working past both dates.

## Audit of the other actions

Checked the declared runtime (`runs.using`) of every action across all workflows and the local composite actions. Everything else is already on Node 24, so no other changes are needed:

| Action | Runtime |
|---|---|
| `softprops/action-gh-release@v2` → `@v3` | node20 → **node24** |
| `actions/checkout@v6` | node24 |
| `actions/setup-java@v5` | node24 |
| `gradle/actions/setup-gradle@v5` | node24 |
| `actions/upload-artifact@v6` | node24 |
| `ffurrer2/extract-release-notes@v3` | node24 |
| `renovatebot/github-action@v46.1.1` | Docker (n/a) |
| local `setup-action`, `kotlin-versions` | composite/bash (n/a) |

The `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` stopgap is unnecessary since no Node 20 action remains.

## Verification

- Workflow YAML still parses.
- The `Create release` step resolves to `softprops/action-gh-release@v3` with the `body`, `prerelease`, and `GITHUB_TOKEN` inputs unchanged and still valid in v3 (`action.yml@v3.0.0` declares `runs.using: "node24"` and retains all three).

Linear: [CLF-94](https://linear.app/squareup/issue/CLF-94/fix-node-20-action-deprecation-in-metro-extensions-publish-release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)